### PR TITLE
chore: update rollup pipeline to generate smaller output

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -38,6 +38,7 @@
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-ts": "^2.0.5",
+        "tslib": "^2.3.1",
         "typescript": "^4.5.4"
       },
       "peerDependencies": {

--- a/react/package.json
+++ b/react/package.json
@@ -3,11 +3,10 @@
   "version": "0.0.1",
   "description": "React components",
   "main": "build/index.js",
-  "module": "build/esm/index.js",
+  "module": "build/index.esm.js",
   "files": [
     "build"
   ],
-  "sideEffects": false,
   "peerDependencies": {
     "@chakra-ui/cli": "^1.7.0",
     "@chakra-ui/react": "^1.7.5",
@@ -38,6 +37,7 @@
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-ts": "^2.0.5",
+    "tslib": "^2.3.1",
     "typescript": "^4.5.4"
   },
   "scripts": {

--- a/react/rollup.config.js
+++ b/react/rollup.config.js
@@ -1,8 +1,7 @@
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
-import ts from 'rollup-plugin-ts'
-import cleanup from 'rollup-plugin-cleanup'
+import typescript from 'rollup-plugin-ts'
 import copy from 'rollup-plugin-copy'
 
 export default {
@@ -14,17 +13,22 @@ export default {
       preserveModules: true,
       preserveModulesRoot: 'src',
       format: 'cjs',
-      sourcemap: true,
     },
     {
       format: 'esm',
-      sourcemap: true,
-      dir: 'build/esm',
+      entryFileNames: '[name].esm.js',
+      dir: 'build',
       preserveModules: true,
       preserveModulesRoot: 'src',
     },
   ],
   plugins: [
+    peerDepsExternal(),
+    resolve({ preferBuiltins: true }),
+    commonjs(),
+    typescript({
+      tsconfig: 'tsconfig.build.json',
+    }),
     copy({
       targets: [
         {
@@ -33,12 +37,5 @@ export default {
         },
       ],
     }),
-    peerDepsExternal(),
-    resolve(),
-    commonjs(),
-    ts({
-      tsconfig: 'tsconfig.build.json',
-    }),
-    cleanup({ comments: 'all' }),
   ],
 }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -5,7 +5,7 @@
       "~/*": ["./src/*"]
     },
     "declaration": true,
-    "emitDeclarationOnly": true,
+    "removeComments": true,
     "module": "esnext",
     "target": "es5",
     "lib": ["es6", "dom", "es2016", "es2017"],


### PR DESCRIPTION
update esm generation to not have duplicate inlined node_modules. This means the bundle output drops from ~18MB to ~10MB.