### PR TITLE
feat: disables netlify build when mdx files are not changed

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+    base = "react/"
+    publish = "storybook-static"
+    command = "npm run build-storybook"
+[context.deploy-preview]
+    # Skip preview build if there are no changes to mdx files in react/src
+    ignore = "curl https://api.github.com/repos/jasonchong96/ogp-design-system-test/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,4 @@
     command = "npm run build-storybook"
 [context.deploy-preview]
     # Skip preview build if there are no changes to mdx files in react/src
-    ignore = "printenv && https://api.github.com/repos/opengovsg/design-system/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"
+    ignore = "curl ${REPOSITORY_URL/'https:\/\/github.com'/https://api.github.com/repos}/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,4 @@
     command = "npm run build-storybook"
 [context.deploy-preview]
     # Skip preview build if there are no changes to mdx files in react/src
-    ignore = "curl ${REPOSITORY_URL/'https:\/\/github.com'/https://api.github.com/repos}/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"
+ignore = "curl ${REPOSITORY_URL/'https://github.com'/https://api.github.com/repos}/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,4 @@
     command = "npm run build-storybook"
 [context.deploy-preview]
     # Skip preview build if there are no changes to mdx files in react/src
-    ignore = "curl https://api.github.com/repos/jasonchong96/ogp-design-system-test/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"
+    ignore = "echo $REPOSITORY_URL && https://api.github.com/repos/opengovsg/design-system/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,4 @@
     command = "npm run build-storybook"
 [context.deploy-preview]
     # Skip preview build if there are no changes to mdx files in react/src
-    ignore = "echo $REPOSITORY_URL && https://api.github.com/repos/opengovsg/design-system/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"
+    ignore = "printenv && https://api.github.com/repos/opengovsg/design-system/pulls/$REVIEW_ID/files | grep -L '\"filename\": \"react/src/.*.mdx\"'"


### PR DESCRIPTION
## Problem

Netlify preview builds run on every PR even when mdx files are unchanged. 
Chromatic review already takes care of component/story changes so netlify preview builds are not needed when mdx files aren't changed

## Solution

Add a `netlify.toml` file to configure netlify builds.
The file specifies that if no (nested or not) mdx files in `react/src` are changed, then don't build a netlify preview

## Notes
You can see that this PR has no netlify preview. (It shows cancelled)