### PR TITLE
fix: require libphonenumber-js as a dependency instead of a peerDependency

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -10,6 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "country-flag-icons": "^1.4.19",
+        "libphonenumber-js": "^1.9.44",
         "react-dropzone": "^11.5.1",
         "simplur": "^3.0.1",
         "unzipit": "^1.4.0",
@@ -32,7 +33,6 @@
         "@zerollup/ts-transform-paths": "^1.7.18",
         "babel-loader": "^8.2.2",
         "chromatic": "^6.3.4",
-        "libphonenumber-js": "^1.9.44",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
@@ -48,7 +48,6 @@
       "peerDependencies": {
         "@chakra-ui/cli": "^1.7.0",
         "@chakra-ui/react": "^1.7.5",
-        "libphonenumber-js": "^1.9.44",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
@@ -15948,8 +15947,7 @@
     "node_modules/libphonenumber-js": {
       "version": "1.9.44",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz",
-      "integrity": "sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g==",
-      "dev": true
+      "integrity": "sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -36519,8 +36517,7 @@
     "libphonenumber-js": {
       "version": "1.9.44",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz",
-      "integrity": "sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g==",
-      "dev": true
+      "integrity": "sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g=="
     },
     "lines-and-columns": {
       "version": "1.2.4",

--- a/react/package.json
+++ b/react/package.json
@@ -13,7 +13,6 @@
   "peerDependencies": {
     "@chakra-ui/cli": "^1.7.0",
     "@chakra-ui/react": "^1.7.5",
-    "libphonenumber-js": "^1.9.44",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
@@ -36,7 +35,6 @@
     "@zerollup/ts-transform-paths": "^1.7.18",
     "babel-loader": "^8.2.2",
     "chromatic": "^6.3.4",
-    "libphonenumber-js": "^1.9.44",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
@@ -58,6 +56,7 @@
   },
   "dependencies": {
     "country-flag-icons": "^1.4.19",
+    "libphonenumber-js": "^1.9.44",
     "react-dropzone": "^11.5.1",
     "simplur": "^3.0.1",
     "unzipit": "^1.4.0",


### PR DESCRIPTION
## Problem

`libphonenumber-js` is not installed on clients who are between npm versions 3 and 7. This is due to `libphonenumber-js` being a peerDependency, which is not automatically installed on npm versions 4-6. [See npm 7 changelog here](https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/). This caused the following error to occur:
```
./node_modules/@opengovsg/design-system-react/build/PhoneNumberInput/PhoneNumberInput.js:8:0
Module not found: Can't resolve 'libphonenumber-js/examples.mobile.json'
```
`examples.mobile.json` is the first file imported from the library
![image](https://user-images.githubusercontent.com/35889982/150926140-233e88a3-ad2f-4858-bc6f-7e67ed70c778.png)

I have also verified that libphonenumber is missing from both `package-lock.json`  and `node_modules` when installing on npm 6 but are present on npm 8.

## Solution

Require libphonenumber-js as a dependency rather than a peerDependency

**Improvements**:

Removed redundant libphonenumber-js entry in devDependency as it is already a dependency
