### PR TITLE
docs: adds libphonenumberjs imissing error and solution to README

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -116,7 +116,7 @@ Module not found: Can't resolve 'libphonenumber-js/examples.mobile.json'
 
 > `libphonenumber-js` is a peer dependency of this design system, and version 8 is automatically installed if your `npm` version is >= 7
 
-If you're on npm version 4 to 6, install `libphonenumber-js` explicitly.
+If you're on npm version 4 to 6, install `libphonenumber-js` explicitly by executing the following command.
 
 ```bash
 $ npm install libphonenumber-js

--- a/react/README.md
+++ b/react/README.md
@@ -108,6 +108,20 @@ Your build pipeline is not configured to run ES Modules. Try using version 6 of 
 $ npm install react-markdown@6
 ```
 
+### I am seeing
+
+```bash
+Module not found: Can't resolve 'libphonenumber-js/examples.mobile.json'
+```
+
+> `libphonenumber-js` is a peer dependency of this design system, and version 8 is automatically installed if your `npm` version is >= 7
+
+If you're on npm version 4 to 6, install `libphonenumber-js` explicitly.
+
+```bash
+$ npm install libphonenumber-js
+```
+
 ## Further reading
 
 As this design system is built on top of ChakraUI, it is (hopefully) fully compatible with ChakraUI's usage. Read [ChakraUI's documentation](https://chakra-ui.com) for all the available props and usage examples.


### PR DESCRIPTION
## Problem

`libphonenumber-js` is a peerDependency which is required to use some components in this design system. However, when the library is not installed, an unhelpful error message is shown, leading to possible confusion.

## Solution

Adds the error message to the README so developers can easily find out the solution to the problem. (Install libphonnumber-js)
