### PR TITLE
build!: bump version to 0.0.8

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opengovsg/design-system-react",
-  "version": "0.0.7-beta.0",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opengovsg/design-system-react",
-      "version": "0.0.7-beta.0",
+      "version": "0.0.8",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "country-flag-icons": "^1.4.19",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/design-system-react",
-  "version": "0.0.7-beta.0",
+  "version": "0.0.8",
   "description": "React components",
   "main": "build/index.js",
   "homepage": "https://github.com/opengovsg/design-system/react#readme",


### PR DESCRIPTION
# Release v0.0.8

This release upgrades React dependency to React 18. Since this package is still below v1.0.0, semver is not followed. 
This package may not work properly with React 17 codebases. 

Please stay on `v0.0.6` or `v0.0.7-beta.0` if using React 17 or below.