### PR TITLE
fix: export missing date-related elements

### DIFF
--- a/react/src/DatePicker/index.ts
+++ b/react/src/DatePicker/index.ts
@@ -1,1 +1,4 @@
-export { DateInput as default } from './DateInput'
+export * from './DateInput'
+export * from './DatePicker'
+export * from './DateRangeInput'
+export * from './DateRangePicker'


### PR DESCRIPTION
## Problem

Closes #37

## Solution

Re-export the components from `DateInput`, `DatePicker`, `DateRangeInput`, and `DateRangePicker` in `DatePicker/index.ts`.