### PR TITLE
fix: add DateRangePicker and DateRangeInput to exports

### DIFF
--- a/react/src/DatePicker/index.ts
+++ b/react/src/DatePicker/index.ts
@@ -1,1 +1,2 @@
 export { DateInput as default } from './DateInput'
+export { DateRangeInput } from './DateRangeInput'


### PR DESCRIPTION
## Problem

DateRangePicker and DateRangeInput were not exported by the design system files as DatePicker does not depend on it.

## Solution

Add an explicit export to DatePicker's `index.ts`
