### PR TITLE
fix: align form info and error text with icon

### DIFF
--- a/react/src/theme/components/Form.ts
+++ b/react/src/theme/components/Form.ts
@@ -9,6 +9,7 @@ export const Form: ComponentMultiStyleConfig<typeof parts> = {
       color: 'secondary.400',
       mt: 2,
       textStyle: 'body-2',
+      lineHeight: '1.25rem',
     },
   },
 }

--- a/react/src/theme/components/FormError.ts
+++ b/react/src/theme/components/FormError.ts
@@ -9,6 +9,7 @@ export const FormError: ComponentMultiStyleConfig<typeof parts> = {
       color: 'danger.500',
       my: '0.5rem',
       textStyle: 'body-2',
+      lineHeight: '1.25rem',
     },
     icon: {
       marginEnd: '0.5em',


### PR DESCRIPTION
## Problem

1. Text for form field success and error messages are not aligned with icon:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/17569254/176835986-10820cd5-6dd1-4785-bbf0-e8657b0b4703.png">
<img width="242" alt="image" src="https://user-images.githubusercontent.com/17569254/176836345-8fc996b8-3fbb-4a42-a659-80bd61dbc48f.png">

2. Height for form field info and success messages are not of the same height (64 vs 61), which causes height of form to change based on validation.
<img width="378" alt="image" src="https://user-images.githubusercontent.com/17569254/176836195-e35ef12f-3e76-4aa6-be6f-c462632cf5d8.png">
<img width="348" alt="image" src="https://user-images.githubusercontent.com/17569254/176836263-115c8c69-7ac8-4e17-bd36-0a4a3100c79e.png">

This is fixed in FormSG, but not in the design system.
https://github.com/opengovsg/FormSG/blob/form-v2/develop/frontend/src/theme/components/Form.ts
https://github.com/opengovsg/FormSG/blob/form-v2/develop/frontend/src/theme/components/FormError.ts


