### PR TITLE
fix: update vite config to fix downstream build

### DIFF
--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
         'react/jsx-dev-runtime',
         'lodash.mergewith',
         'lodash',
+        'date-fns-tz',
         ...Object.keys(PackageJson.peerDependencies),
       ],
       output: [


### PR DESCRIPTION
## Problem

Encountering `TypeError: $2.zonedTimeToUtc is not a function` in downstream project using current version. This change configures `date-fns-tz` imports correctly so it finds the function. 