### PR TITLE
feat: export RestrictedFooter types and constants

### DIFF
--- a/react/src/RestrictedFooter/RestrictedFooter.tsx
+++ b/react/src/RestrictedFooter/RestrictedFooter.tsx
@@ -24,7 +24,19 @@ export const RestrictedFooter = ({
     { ssr },
   )
 
-  const colorModeToUse = colorModeProp ?? colorMode
+  const colorModeBreakpointValues = useMemo(() => {
+    if (!colorModeProp) return { base: undefined }
+    if (typeof colorModeProp === 'string') {
+      return { base: colorModeProp }
+    }
+    return colorModeProp
+  }, [colorModeProp])
+
+  const colorModePropValue = useBreakpointValue(colorModeBreakpointValues, {
+    ssr,
+  })
+
+  const colorModeToUse = colorModePropValue ?? colorMode
 
   const ogpFooterIconLink = useMemo(() => {
     return colorModeToUse === 'dark'

--- a/react/src/RestrictedFooter/common/types.ts
+++ b/react/src/RestrictedFooter/common/types.ts
@@ -38,7 +38,7 @@ export interface RestrictedFooterVariantProps {
   /**
    * Whether to render the footer in dark or light mode.
    */
-  colorMode?: StyleFunctionProps['colorMode']
+  colorMode?: ResponsiveValue<StyleFunctionProps['colorMode']>
 }
 
 export interface RestrictedFooterProps

--- a/react/src/RestrictedFooter/index.ts
+++ b/react/src/RestrictedFooter/index.ts
@@ -1,1 +1,3 @@
+export * from './common/constants'
+export * from './common/types'
 export * from './RestrictedFooter'


### PR DESCRIPTION
Types for the `RestrictedFooter` component were not exported. This PR exports them.