### PR TITLE
build: remove sideEffects prop from package.json

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -4,7 +4,6 @@
   "description": "React components",
   "homepage": "https://github.com/opengovsg/design-system/react#readme",
   "bugs": "https://github.com/opengovsg/design-system/issues",
-  "sideEffects": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "files": [
     "build/main",


### PR DESCRIPTION
Fixes bug with storybook theme not rendering.
Not sure if `sideEffects` is needed, will need more testing for tree-shakeability changes, but resulting packed size did not change (so suspect no code differences) See https://github.com/storybookjs/storybook/issues/20704
