### PR TITLE
feat(story): update components and sb config for better story source code blocks

### DIFF
--- a/react/.storybook/preview.tsx
+++ b/react/.storybook/preview.tsx
@@ -43,19 +43,19 @@ export const THEME_ADDON_BAR_ITEMS = Object.keys(THEME_MAP).map((key) => ({
   title: key,
 }))
 
-const withTheme: Decorator = (StoryFn, context) => {
+const withTheme: Decorator = (storyFn, context) => {
   // Get values from story parameter first, else fallback to globals
   const theme = context.parameters.theme || context.globals.theme
   const themeToUse = THEME_MAP[theme]
 
   return (
     <ThemeProvider theme={themeToUse ?? defaultTheme}>
-      <StoryFn />
+      {storyFn()}
     </ThemeProvider>
   )
 }
 
-const withColorMode: Decorator = (StoryFn, context) => {
+const withColorMode: Decorator = (storyFn, context) => {
   const colorMode =
     context.parameters.colorMode ||
     get(context, 'globals.backgrounds.value') === backgrounds.dark.value
@@ -64,7 +64,7 @@ const withColorMode: Decorator = (StoryFn, context) => {
 
   return (
     <ColorModeProvider value={colorMode}>
-      <StoryFn />
+      {storyFn()}
     </ColorModeProvider>
   )
 }

--- a/react/.storybook/preview.tsx
+++ b/react/.storybook/preview.tsx
@@ -26,6 +26,9 @@ export const parameters = {
   docs: {
     theme: StorybookTheme.docs,
     inlineStories: true,
+    source: {
+      excludeDecorators: true,
+    }
   },
   controls: {
     matchers: {

--- a/react/src/Attachment/Attachment.tsx
+++ b/react/src/Attachment/Attachment.tsx
@@ -257,3 +257,5 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
     )
   },
 )
+
+Attachment.displayName = 'Attachment'

--- a/react/src/Attachment/AttachmentFileInfo.tsx
+++ b/react/src/Attachment/AttachmentFileInfo.tsx
@@ -79,3 +79,5 @@ export const AttachmentFileInfo = forwardRef<AttachmentFileInfoProps, 'div'>(
     )
   },
 )
+
+AttachmentFileInfo.displayName = 'AttachmentFileInfo'

--- a/react/src/Button/Button.tsx
+++ b/react/src/Button/Button.tsx
@@ -50,3 +50,5 @@ export const Button = forwardRef<ButtonProps, 'button'>(
     )
   },
 )
+
+Button.displayName = 'Button'

--- a/react/src/Calendar/Calendar.tsx
+++ b/react/src/Calendar/Calendar.tsx
@@ -62,3 +62,5 @@ export const Calendar = forwardRef<CalendarProps, 'input'>(
     )
   },
 )
+
+Calendar.displayName = 'Calendar'

--- a/react/src/Calendar/CalendarBase/CalendarPanel.tsx
+++ b/react/src/Calendar/CalendarBase/CalendarPanel.tsx
@@ -105,3 +105,5 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
     )
   },
 )
+
+CalendarPanel.displayName = 'CalendarPanel'

--- a/react/src/Calendar/CalendarBase/DayOfMonth.tsx
+++ b/react/src/Calendar/CalendarBase/DayOfMonth.tsx
@@ -158,3 +158,5 @@ export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
     )
   },
 )
+
+DayOfMonth.displayName = 'DayOfMonth'

--- a/react/src/Calendar/RangeCalendar.tsx
+++ b/react/src/Calendar/RangeCalendar.tsx
@@ -151,3 +151,5 @@ export const RangeCalendar = forwardRef<RangeCalendarProps, 'input'>(
     )
   },
 )
+
+RangeCalendar.displayName = 'RangeCalendar'

--- a/react/src/Checkbox/Checkbox.tsx
+++ b/react/src/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, ReactNode, useRef } from 'react'
+import { ChangeEventHandler, FC, ReactNode, useRef } from 'react'
 import {
   Box,
   Checkbox as ChakraCheckbox,
@@ -66,10 +66,10 @@ export interface CheckboxOthersWrapperProps {
 /**
  * Provides context values for the Others option.
  */
-const OthersWrapper = ({
+const OthersWrapper: FC<CheckboxOthersWrapperProps> = ({
   children,
   ...props
-}: CheckboxOthersWrapperProps): JSX.Element => {
+}) => {
   const checkboxRef = useRef<HTMLInputElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   // Passing all props for cleanliness but size and colorScheme are the most relevant
@@ -147,3 +147,7 @@ OthersInput.displayName = 'OthersInput'
 Checkbox.OthersWrapper = OthersWrapper
 Checkbox.OthersCheckbox = OthersCheckbox
 Checkbox.OthersInput = OthersInput
+
+Checkbox.OthersInput.displayName = 'Checkbox.OthersInput'
+Checkbox.OthersWrapper.displayName = 'Checkbox.OthersWrapper'
+Checkbox.OthersCheckbox.displayName = 'Checkbox.OthersCheckbox'

--- a/react/src/Checkbox/Checkbox.tsx
+++ b/react/src/Checkbox/Checkbox.tsx
@@ -48,6 +48,8 @@ export const Checkbox = forwardRef<CheckboxProps, 'input'>(
   },
 ) as CheckboxWithOthers
 
+Checkbox.displayName = 'Checkbox'
+
 /**
  * Components to support the "Others" option.
  */
@@ -111,6 +113,8 @@ const OthersCheckbox = forwardRef<CheckboxProps, 'input'>((props, ref) => {
   )
 })
 
+OthersCheckbox.displayName = 'OthersCheckbox'
+
 /**
  * Wrapper for the input part of the Others option.
  */
@@ -137,6 +141,8 @@ const OthersInput = forwardRef<InputProps, 'input'>((props, ref) => {
     />
   )
 })
+
+OthersInput.displayName = 'OthersInput'
 
 Checkbox.OthersWrapper = OthersWrapper
 Checkbox.OthersCheckbox = OthersCheckbox

--- a/react/src/DatePicker/DatePicker.tsx
+++ b/react/src/DatePicker/DatePicker.tsx
@@ -31,3 +31,5 @@ export const DatePicker = forwardRef<DatePickerProps, 'input'>((props, ref) => {
     </DatePickerProvider>
   )
 })
+
+DatePicker.displayName = 'DatePicker'

--- a/react/src/DatePicker/components/DatePickerInput.tsx
+++ b/react/src/DatePicker/components/DatePickerInput.tsx
@@ -78,3 +78,5 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
     </>
   )
 })
+
+DatePickerInput.displayName = 'DatePickerInput'

--- a/react/src/DatePicker/components/DatePickerWrapper.tsx
+++ b/react/src/DatePicker/components/DatePickerWrapper.tsx
@@ -42,3 +42,5 @@ export const DatePickerWrapper = forwardRef<{}, 'input'>(
     )
   },
 )
+
+DatePickerWrapper.displayName = 'DatePickerWrapper'

--- a/react/src/DateRangePicker/DateRangePicker.tsx
+++ b/react/src/DateRangePicker/DateRangePicker.tsx
@@ -33,3 +33,5 @@ export const DateRangePicker = forwardRef<DateRangePickerProps, 'input'>(
     )
   },
 )
+
+DateRangePicker.displayName = 'DateRangePicker'

--- a/react/src/DateRangePicker/components/DateRangePickerInput.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerInput.tsx
@@ -135,3 +135,5 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
     </Flex>
   )
 })
+
+DateRangePickerInput.displayName = 'DateRangePickerInput'

--- a/react/src/DateRangePicker/components/DateRangePickerWrapper.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerWrapper.tsx
@@ -62,3 +62,5 @@ export const DateRangePickerWrapper = forwardRef<{}, 'input'>(
     )
   },
 )
+
+DateRangePickerWrapper.displayName = 'DateRangePickerWrapper'

--- a/react/src/IconButton/IconButton.tsx
+++ b/react/src/IconButton/IconButton.tsx
@@ -49,3 +49,5 @@ export const IconButton = forwardRef<IconButtonProps, 'button'>(
     )
   },
 )
+
+IconButton.displayName = 'IconButton'

--- a/react/src/Input/Input.tsx
+++ b/react/src/Input/Input.tsx
@@ -64,3 +64,5 @@ export const Input = forwardRef<InputProps, 'input'>((props, ref) => {
  * https://github.com/chakra-ui/chakra-ui/blob/main/packages/input/src/input-group.tsx#L58.
  */
 Input.id = 'Input'
+
+Input.displayName = 'Input'

--- a/react/src/Link/Link.tsx
+++ b/react/src/Link/Link.tsx
@@ -66,4 +66,6 @@ const ExternalIcon = (): JSX.Element => {
   )
 }
 
+Link.displayName = 'Link'
+
 Link.ExternalIcon = ExternalIcon

--- a/react/src/Link/Link.tsx
+++ b/react/src/Link/Link.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react'
 import {
   ComponentWithAs,
   forwardRef,
@@ -60,7 +61,7 @@ export const Link = forwardRef<LinkProps, 'a'>(
   },
 ) as LinkWithParts
 
-const ExternalIcon = (): JSX.Element => {
+const ExternalIcon: FC = (): JSX.Element => {
   return (
     <Icon aria-hidden as={BxLinkExternal} ml="0.25rem" verticalAlign="middle" />
   )
@@ -69,3 +70,4 @@ const ExternalIcon = (): JSX.Element => {
 Link.displayName = 'Link'
 
 Link.ExternalIcon = ExternalIcon
+Link.ExternalIcon.displayName = 'Link.ExternalIcon'

--- a/react/src/Menu/Menu.stories.tsx
+++ b/react/src/Menu/Menu.stories.tsx
@@ -20,6 +20,7 @@ export default {
   title: 'Components/Menu',
   component: Menu,
   tags: ['autodocs'],
+  parameters: { docs: { source: { type: 'code' } } },
 } as Meta
 
 type MenuTemplateProps = MenuButtonProps & {

--- a/react/src/Menu/Menu.tsx
+++ b/react/src/Menu/Menu.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { useMemo } from 'react'
+import { FC, useMemo } from 'react'
 import {
   Icon,
   Menu as ChakraMenu,
@@ -26,12 +25,12 @@ export interface MenuButtonProps extends Omit<ButtonProps, 'isFullWidth'> {
  * @preconditions Must be a child of Menu component,
  * and returned using a render prop (see implementation in Menu.stories).
  */
-const MenuButton = ({
+const MenuButton: FC<MenuButtonProps> = ({
   isOpen,
   isStretch,
   chevronSize,
   ...props
-}: MenuButtonProps): JSX.Element => {
+}) => {
   const styles = useMultiStyleConfig('Menu', props)
   const ChevronIcon = useMemo(
     () => (
@@ -90,3 +89,8 @@ Menu.Button = MenuButton
 Menu.List = MenuList
 Menu.Item = MenuItem
 Menu.Divider = MenuDivider
+
+Menu.Button.displayName = 'Menu.Button'
+Menu.List.displayName = 'Menu.List'
+Menu.Item.displayName = 'Menu.Item'
+Menu.Divider.displayName = 'Menu.Divider'

--- a/react/src/MultiSelect/MultiSelect.tsx
+++ b/react/src/MultiSelect/MultiSelect.tsx
@@ -23,3 +23,5 @@ export const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
     )
   },
 )
+
+MultiSelect.displayName = 'MultiSelect'

--- a/react/src/MultiSelect/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/react/src/MultiSelect/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -106,3 +106,5 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
     )
   },
 )
+
+MultiSelectCombobox.displayName = 'MultiSelectCombobox'

--- a/react/src/MultiSelect/components/MultiSelectMenu.tsx
+++ b/react/src/MultiSelect/components/MultiSelectMenu.tsx
@@ -26,10 +26,15 @@ export const MultiSelectMenu = (): JSX.Element => {
     <Portal>
       <List
         style={floatingStyles}
-        {...getMenuProps({
-          hidden: !isOpen,
-          ref: floatingRef,
-        })}
+        {...getMenuProps(
+          {
+            hidden: !isOpen,
+            ref: floatingRef,
+          },
+          {
+            suppressRefError: true,
+          },
+        )}
         sx={styles.list}
       >
         {isOpen && items.length > 0 && (

--- a/react/src/NumberInput/NumberInput.tsx
+++ b/react/src/NumberInput/NumberInput.tsx
@@ -114,3 +114,5 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
     )
   },
 )
+
+NumberInput.displayName = 'NumberInput'

--- a/react/src/Pagination/Pagination.tsx
+++ b/react/src/Pagination/Pagination.tsx
@@ -62,3 +62,6 @@ export const Pagination = ({
 
 Pagination.Full = PaginationFull
 Pagination.Minimal = PaginationMinimal
+
+Pagination.Full.displayName = 'Pagination.Full'
+Pagination.Minimal.displayName = 'Pagination.Minimal'

--- a/react/src/Pagination/PaginationFull.tsx
+++ b/react/src/Pagination/PaginationFull.tsx
@@ -2,7 +2,7 @@
  * Desktop variant for the Pagination component.
  */
 
-import { useCallback, useMemo } from 'react'
+import { FC, useCallback, useMemo } from 'react'
 import {
   Button,
   chakra,
@@ -63,14 +63,14 @@ const FullPageButton = ({
   )
 }
 
-export const PaginationFull = ({
+export const PaginationFull: FC<PaginationProps> = ({
   siblingCount = 1,
   pageSize,
   onPageChange,
   totalCount,
   currentPage,
   isDisabled,
-}: PaginationProps): JSX.Element => {
+}) => {
   const paginationRange = usePaginationRange<typeof SEPARATOR>({
     totalCount,
     pageSize,

--- a/react/src/Pagination/PaginationMinimal.tsx
+++ b/react/src/Pagination/PaginationMinimal.tsx
@@ -2,7 +2,7 @@
  * Mobile variant for the Pagination component.
  */
 
-import { useCallback } from 'react'
+import { FC, useCallback } from 'react'
 import { Box, IconButton, Text, useMultiStyleConfig } from '@chakra-ui/react'
 
 import { BxChevronLeft, BxChevronRight } from '~/icons'
@@ -11,13 +11,13 @@ import { PaginationProps } from './Pagination'
 
 type PaginationMobileProps = Omit<PaginationProps, 'siblingCount'>
 
-export const PaginationMinimal = ({
+export const PaginationMinimal: FC<PaginationMobileProps> = ({
   pageSize,
   onPageChange,
   totalCount,
   currentPage,
   isDisabled,
-}: PaginationMobileProps): JSX.Element => {
+}) => {
   const styles = useMultiStyleConfig('Pagination', { variant: 'minimal' })
 
   const totalPageCount = Math.ceil(totalCount / pageSize)

--- a/react/src/PhoneNumberInput/IntlPhoneNumberInput.tsx
+++ b/react/src/PhoneNumberInput/IntlPhoneNumberInput.tsx
@@ -130,3 +130,5 @@ const CountrySelect: FC<CountrySelectProps> = (props) => {
     </InputLeftAddon>
   )
 }
+
+IntlPhoneNumberInput.displayName = 'IntlPhoneNumberInput'

--- a/react/src/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/react/src/PhoneNumberInput/PhoneNumberInput.tsx
@@ -117,3 +117,5 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, 'input'>(
     )
   },
 )
+
+PhoneNumberInput.displayName = 'PhoneNumberInput'

--- a/react/src/PhoneNumberInput/SingleCountryPhoneNumberInput.tsx
+++ b/react/src/PhoneNumberInput/SingleCountryPhoneNumberInput.tsx
@@ -54,3 +54,5 @@ export const SingleCountryPhoneNumberInput = forwardRef<
     </InputGroup>
   )
 })
+
+SingleCountryPhoneNumberInput.displayName = 'SingleCountryPhoneNumberInput'

--- a/react/src/Radio/Radio.tsx
+++ b/react/src/Radio/Radio.tsx
@@ -329,3 +329,7 @@ OthersWrapper.displayName = 'OthersWrapper'
 Radio.OthersWrapper = OthersWrapper
 Radio.RadioGroup = RadioGroup
 Radio.OthersInput = OthersInput
+
+Radio.OthersWrapper.displayName = 'Radio.OthersWrapper'
+Radio.RadioGroup.displayName = 'Radio.RadioGroup'
+Radio.OthersInput.displayName = 'Radio.OthersInput'

--- a/react/src/Radio/Radio.tsx
+++ b/react/src/Radio/Radio.tsx
@@ -267,6 +267,8 @@ const OthersRadio = forwardRef<RadioProps, 'input'>((props, ref) => {
   )
 })
 
+OthersRadio.displayName = 'OthersRadio'
+
 /**
  * Wrapper for the input part of the Others option.
  */
@@ -296,6 +298,8 @@ export const OthersInput = forwardRef<InputProps, 'input'>(
   },
 )
 
+OthersInput.displayName = 'OthersInput'
+
 export interface OthersProps extends RadioProps {
   children: React.ReactNode
 }
@@ -319,6 +323,8 @@ const OthersWrapper = forwardRef<OthersProps, 'input'>(
     )
   },
 )
+
+OthersWrapper.displayName = 'OthersWrapper'
 
 Radio.OthersWrapper = OthersWrapper
 Radio.RadioGroup = RadioGroup

--- a/react/src/Radio/RadioGroup.tsx
+++ b/react/src/Radio/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { FC, useRef } from 'react'
 import {
   RadioGroup as ChakraRadioGroup,
   RadioGroupProps as ChakraRadioGroupProps,
@@ -9,11 +9,11 @@ import { RadioGroupContext } from './useRadioGroupWithOthers'
 /**
  * Container for a group of radio buttons.
  */
-export const RadioGroup = ({
+export const RadioGroup: FC<ChakraRadioGroupProps> = ({
   onChange,
   children,
   ...props
-}: ChakraRadioGroupProps): JSX.Element => {
+}) => {
   const othersRadioRef = useRef<HTMLInputElement>(null)
   const othersInputRef = useRef<HTMLInputElement>(null)
 

--- a/react/src/RestrictedFooter/RestrictedCompactFooter.tsx
+++ b/react/src/RestrictedFooter/RestrictedCompactFooter.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo } from 'react'
+import { FC, Fragment, useMemo } from 'react'
 import {
   Box,
   DarkMode,
@@ -94,10 +94,10 @@ export const RestrictedCompactFooter = ({
   )
 }
 
-const RestrictedCompactFooterContainer = ({
+const RestrictedCompactFooterContainer: FC<RestrictedFooterContainerProps> = ({
   children,
   ...props
-}: RestrictedFooterContainerProps): JSX.Element => {
+}) => {
   const styles = useFooterStyles()
 
   return (
@@ -108,3 +108,5 @@ const RestrictedCompactFooterContainer = ({
 }
 
 RestrictedCompactFooter.Container = RestrictedCompactFooterContainer
+RestrictedCompactFooter.Container.displayName =
+  'RestrictedCompactFooter.Container'

--- a/react/src/Searchbar/Searchbar.tsx
+++ b/react/src/Searchbar/Searchbar.tsx
@@ -165,3 +165,5 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
     )
   },
 )
+
+Searchbar.displayName = 'Searchbar'

--- a/react/src/SingleSelect/SingleSelect.tsx
+++ b/react/src/SingleSelect/SingleSelect.tsx
@@ -22,3 +22,5 @@ export const SingleSelect = forwardRef<HTMLInputElement, SingleSelectProps>(
     )
   },
 )
+
+SingleSelect.displayName = 'SingleSelect'

--- a/react/src/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/react/src/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -109,3 +109,5 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
     )
   },
 )
+
+SelectCombobox.displayName = 'SelectCombobox'

--- a/react/src/Switch/Switch.tsx
+++ b/react/src/Switch/Switch.tsx
@@ -198,3 +198,5 @@ export const Switch = forwardRef<SwitchProps, 'input'>(
     )
   },
 )
+
+Switch.displayName = 'Switch'

--- a/react/src/Tag/Tag.tsx
+++ b/react/src/Tag/Tag.tsx
@@ -74,3 +74,5 @@ export const Tag = forwardRef<TagProps, 'span'>((props, ref): JSX.Element => {
     </StylesProvider>
   )
 })
+
+Tag.displayName = 'Tag'

--- a/react/src/Textarea/Textarea.tsx
+++ b/react/src/Textarea/Textarea.tsx
@@ -51,3 +51,5 @@ export const Textarea = forwardRef<TextareaProps, 'textarea'>(
     )
   },
 )
+
+Textarea.displayName = 'Textarea'

--- a/react/src/Tile/Tile.stories.tsx
+++ b/react/src/Tile/Tile.stories.tsx
@@ -13,7 +13,6 @@ export default {
   component: Tile,
   tags: ['autodocs'],
   decorators: [],
-  parameters: { docs: { source: { type: 'code' } } },
 } as Meta
 
 const List = ({

--- a/react/src/Tile/Tile.stories.tsx
+++ b/react/src/Tile/Tile.stories.tsx
@@ -15,7 +15,7 @@ export default {
   decorators: [],
 } as Meta
 
-const List = ({
+const StorybookListChildrenExample = ({
   listTitle,
   listItems = [],
 }: {
@@ -74,7 +74,10 @@ const Template: StoryFn<TileTemplateProps> = ({
       <Tile.Title>{title}</Tile.Title>
       <Tile.Subtitle>{subtitle}</Tile.Subtitle>
       {hasDescription && (
-        <List listTitle={listTitle} listItems={values(listItems)} />
+        <StorybookListChildrenExample
+          listTitle={listTitle}
+          listItems={values(listItems)}
+        />
       )}
     </Tile>
   )
@@ -138,7 +141,7 @@ const EmailTile = ({ onClick, isSelected }: StoryTileProps) => (
   >
     <Tile.Title>Email Mode</Tile.Title>
     <Tile.Subtitle>Receive responses in your inbox</Tile.Subtitle>
-    <List
+    <StorybookListChildrenExample
       listTitle="Who is it for:"
       listItems={['Emailed copy of response', 'MyInfo fields']}
     />
@@ -156,7 +159,7 @@ const StorageTile = ({ onClick, isSelected }: StoryTileProps) => (
   >
     <Tile.Title>Storage Mode</Tile.Title>
     <Tile.Subtitle>Receive responses in Form</Tile.Subtitle>
-    <List
+    <StorybookListChildrenExample
       listTitle="Who is it for:"
       listItems={['High-volume forms', 'End to end encryption needs']}
     />

--- a/react/src/Tile/Tile.stories.tsx
+++ b/react/src/Tile/Tile.stories.tsx
@@ -13,6 +13,7 @@ export default {
   component: Tile,
   tags: ['autodocs'],
   decorators: [],
+  parameters: { docs: { source: { type: 'code' } } },
 } as Meta
 
 const List = ({
@@ -35,9 +36,24 @@ const List = ({
 )
 
 interface TileTemplateProps extends TileProps {
+  /**
+   * This is a story-only prop, and NOT a prop of the component itself.
+   * Use the `Tile.Title` subcomponent to render the title.
+   */
   title: string
+
+  /**
+   * This is a story-only prop, and NOT a prop of the component itself.
+   * Use the `Tile.Subtitle` subcomponent to render the title.
+   */
   subtitle: string
+  /**
+   * This is a story-only prop, and NOT a prop of the component itself.
+   */
   listTitle: string
+  /**
+   * This is a story-only prop, and NOT a prop of the component itself.
+   */
   listItems: Record<string, string>
 }
 

--- a/react/src/Tile/Tile.tsx
+++ b/react/src/Tile/Tile.tsx
@@ -105,6 +105,8 @@ const TileText = (props: TextProps): JSX.Element => {
   return <Text sx={styles.text} {...props} />
 }
 
+Tile.displayName = 'Tile'
+
 Tile.Title = TileTitle
 Tile.Subtitle = TileSubtitle
 Tile.Text = TileText

--- a/react/src/Tile/Tile.tsx
+++ b/react/src/Tile/Tile.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react'
 import {
   As,
   Button,
@@ -87,26 +88,29 @@ export const Tile = forwardRef<TileProps, 'button'>(
   },
 ) as TileWithParts
 
-const TileTitle = (props: TextProps): JSX.Element => {
+const TileTitle: FC<TextProps> = (props) => {
   const styles = useTileStyles()
   // Allow consumers to override default style props with their own styling
   return <Text sx={styles.title} {...props} />
 }
 
-const TileSubtitle = (props: TextProps): JSX.Element => {
+const TileSubtitle: FC<TextProps> = (props) => {
   const styles = useTileStyles()
   // Allow consumers to override default style props with their own styling
   return <Text sx={styles.subtitle} {...props} />
 }
 
-const TileText = (props: TextProps): JSX.Element => {
+const TileText: FC<TextProps> = (props) => {
   const styles = useTileStyles()
   // Allow consumers to override default style props with their own styling
   return <Text sx={styles.text} {...props} />
 }
 
-Tile.displayName = 'Tile'
-
 Tile.Title = TileTitle
 Tile.Subtitle = TileSubtitle
 Tile.Text = TileText
+
+Tile.displayName = 'Tile'
+Tile.Title.displayName = 'Tile.Title'
+Tile.Subtitle.displayName = 'Tile.Subtitle'
+Tile.Text.displayName = 'Tile.Text'

--- a/react/src/Toggle/Toggle.tsx
+++ b/react/src/Toggle/Toggle.tsx
@@ -78,3 +78,5 @@ export const Toggle = forwardRef<ToggleProps, 'input'>(
     )
   },
 )
+
+Toggle.displayName = 'Toggle'

--- a/react/src/icons/BxsCheckCircle.tsx
+++ b/react/src/icons/BxsCheckCircle.tsx
@@ -17,3 +17,5 @@ export const BxsCheckCircle = forwardRef<
     </svg>
   )
 })
+
+BxsCheckCircle.displayName = 'BxsCheckCircle'

--- a/react/src/icons/BxsHelpCircle.tsx
+++ b/react/src/icons/BxsHelpCircle.tsx
@@ -17,3 +17,5 @@ export const BxsHelpCircle = forwardRef<
     </svg>
   )
 })
+
+BxsHelpCircle.displayName = 'BxsHelpCircle'

--- a/react/src/icons/BxsInfoCircle.tsx
+++ b/react/src/icons/BxsInfoCircle.tsx
@@ -17,3 +17,5 @@ export const BxsInfoCircle = forwardRef<
     </svg>
   )
 })
+
+BxsInfoCircle.displayName = 'BxsInfoCircle'

--- a/react/src/utils/storybook.tsx
+++ b/react/src/utils/storybook.tsx
@@ -18,12 +18,8 @@ const breakpointToViewportWidth = (breakpoint: keyof typeof breakpoints) => {
 
 export const fixedHeightDecorator =
   (height: BoxProps['h']): Decorator =>
-  (Story) =>
-    (
-      <Box h={height}>
-        <Story />
-      </Box>
-    )
+  (storyFn) =>
+    <Box h={height}>{storyFn()}</Box>
 
 /**
  * Viewports mapping viewport key to their width in (pixel) number.


### PR DESCRIPTION
This PR enables better source code blocks in stories by correctly adding `displayName` props to the components.

See before and after example of the `Tile` component story below (and others):

### Before
```tsx
<Tile
  badge={<f colorScheme="success">recommended</f>}
  icon={function Ka(){}}
  onClick={function Ka(){}}
  variant="complex"
>
  <g>
    Complex
  </g>
  <V>
    Receive responses in forms
  </V>
  <m
    listItems={[
      'item 1',
      'item 2'
    ]}
    listTitle="description"
  />
</Tile>
```

### After
```tsx
<Tile
  badge={<Badge colorScheme="success">recommended</Badge>}
  icon={() => {}}
  onClick={() => {}}
  variant="complex"
>
  <Tile.Title>
    Complex
  </Tile.Title>
  <Tile.Subtitle>
    Receive responses in forms
  </Tile.Subtitle>
  <List
    listItems={[
      'item 1',
      'item 2'
    ]}
    listTitle="description"
  />
</Tile>
```