### PR TITLE
feat: downgrade nanoid to latest CJS-supported version

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -21,7 +21,7 @@
         "inter-ui": "^3.19.3",
         "libphonenumber-js": "^1.9.44",
         "lodash": "^4.17.21",
-        "nanoid": "^4.0.0",
+        "nanoid": "^3.3.4",
         "react-dropzone": "^11.5.1",
         "react-input-mask": "^3.0.0-alpha.2",
         "react-roving-tabindex": "^3.2.0",
@@ -6795,18 +6795,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@storybook/telemetry/node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/@storybook/telemetry/node_modules/supports-color": {
@@ -14924,14 +14912,14 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/nanomatch": {
@@ -15934,18 +15922,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -24946,12 +24922,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "nanoid": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -31017,9 +30987,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -31752,14 +31722,6 @@
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-          "dev": true
-        }
       }
     },
     "prelude-ls": {

--- a/react/package.json
+++ b/react/package.json
@@ -45,7 +45,7 @@
     "inter-ui": "^3.19.3",
     "libphonenumber-js": "^1.9.44",
     "lodash": "^4.17.21",
-    "nanoid": "^4.0.0",
+    "nanoid": "^3.3.4",
     "react-dropzone": "^11.5.1",
     "react-input-mask": "^3.0.0-alpha.2",
     "react-roving-tabindex": "^3.2.0",


### PR DESCRIPTION
#200 installs `nanoid`, which dropped CJS support in v4. This results in failing builds downstream:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/cal-sg/cal-sg/frontend/node_modules/@opengovsg/design-system-react/node_modules/nanoid/non-secure/index.js from /home/runner/work/cal-sg/cal-sg/frontend/node_modules/@opengovsg/design-system-react/build/main/Calendar/CalendarBase/CalendarContext.js not supported.
Instead change the require of index.js in /home/runner/work/cal-sg/cal-sg/frontend/node_modules/@opengovsg/design-system-react/build/main/Calendar/CalendarBase/CalendarContext.js to a dynamic import() which is available in all CommonJS modules.
```

Solution is to downgrade to v3, which will be [supported](https://github.com/ai/nanoid/blob/main/CHANGELOG.md#40) for users who cannot migrate to ESM.