### PR TITLE
fix(DateRangePicker): avoid kebab case for object css

### DIFF
--- a/react/src/DateRangePicker/components/DateRangePickerInput.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerInput.tsx
@@ -57,7 +57,7 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
       overflowX="auto"
       sx={{
         // Hide scrollbars so dual inputs feel like a real normal input.
-        '-ms-overflow-style': 'none',
+        msOverflowStyle: 'none',
         scrollbarWidth: 'none',
         '&::-webkit-scrollbar': {
           display: 'none',


### PR DESCRIPTION
Fixes the following console error:
<img width="423" alt="Screenshot 2023-02-01 at 11 18 46 AM" src="https://user-images.githubusercontent.com/29480346/215936988-8b8fc1f0-76fd-4a01-866f-31f65f92cc41.png">
