### PR TITLE
feat: add ssr, link.isExternalFn props to useMdComponent hook

### DIFF
--- a/react/src/Banner/Banner.tsx
+++ b/react/src/Banner/Banner.tsx
@@ -14,8 +14,9 @@ import {
 import { useMdComponents } from '~/hooks/useMdComponents'
 import { BxsErrorCircle, BxsInfoCircle, BxX } from '~/icons'
 import { BannerVariant } from '~/theme/components/Banner'
+import type { WithSsr } from '~/types/WithSsr'
 
-export interface BannerProps {
+export interface BannerProps extends WithSsr {
   variant?: BannerVariant
   children: string
   /**
@@ -48,6 +49,7 @@ export const Banner = ({
   isDismissable: isDismissableProp,
   icon: iconProp,
   closeButton,
+  ssr,
 }: BannerProps): JSX.Element => {
   const { isOpen, onToggle } = useDisclosure({
     defaultIsOpen: true,
@@ -55,7 +57,7 @@ export const Banner = ({
 
   const styles = useMultiStyleConfig('Banner', { variant })
 
-  const mdComponents = useMdComponents({ styles })
+  const mdComponents = useMdComponents({ styles, ssr })
   const iconToUse = useMemo(() => {
     if (iconProp) {
       return iconProp

--- a/react/src/Banner/Banner.tsx
+++ b/react/src/Banner/Banner.tsx
@@ -14,9 +14,9 @@ import {
 import { useMdComponents } from '~/hooks/useMdComponents'
 import { BxsErrorCircle, BxsInfoCircle, BxX } from '~/icons'
 import { BannerVariant } from '~/theme/components/Banner'
-import type { WithSsr } from '~/types/WithSsr'
+import type { WithReactMarkdownSsr } from '~/types/WithSsr'
 
-export interface BannerProps extends WithSsr {
+export interface BannerProps extends WithReactMarkdownSsr {
   variant?: BannerVariant
   children: string
   /**
@@ -50,6 +50,7 @@ export const Banner = ({
   icon: iconProp,
   closeButton,
   ssr,
+  mdIsExternalLinkFn,
 }: BannerProps): JSX.Element => {
   const { isOpen, onToggle } = useDisclosure({
     defaultIsOpen: true,
@@ -57,7 +58,17 @@ export const Banner = ({
 
   const styles = useMultiStyleConfig('Banner', { variant })
 
-  const mdComponents = useMdComponents({ styles, ssr })
+  const mdComponents = useMdComponents({
+    styles: {
+      link: styles.link,
+    },
+    ssr,
+    props: {
+      link: {
+        isExternalFn: mdIsExternalLinkFn,
+      },
+    },
+  })
   const iconToUse = useMemo(() => {
     if (iconProp) {
       return iconProp

--- a/react/src/FormControl/FormLabel/FormLabel.tsx
+++ b/react/src/FormControl/FormLabel/FormLabel.tsx
@@ -15,8 +15,9 @@ import {
 import { useMdComponents } from '~/hooks/useMdComponents'
 import { BxsHelpCircle } from '~/icons/BxsHelpCircle'
 import { Tooltip } from '~/Tooltip'
+import type { WithSsr } from '~/types/WithSsr'
 
-export interface FormLabelProps extends ChakraFormLabelProps {
+export interface FormLabelProps extends ChakraFormLabelProps, WithSsr {
   /**
    * Question number to be prefixed before each label, if any.
    */
@@ -61,6 +62,7 @@ export const FormLabel = ({
   description,
   useMarkdownForDescription = false,
   children,
+  ssr,
   ...labelProps
 }: FormLabelProps): JSX.Element => {
   return (
@@ -88,7 +90,10 @@ export const FormLabel = ({
         )}
       </Box>
       {description && (
-        <FormLabel.Description useMarkdown={useMarkdownForDescription}>
+        <FormLabel.Description
+          ssr={ssr}
+          useMarkdown={useMarkdownForDescription}
+        >
           {description}
         </FormLabel.Description>
       )}
@@ -98,13 +103,14 @@ export const FormLabel = ({
 
 FormLabel.Label = ChakraFormLabel
 
-interface FormLabelDescriptionProps extends TextProps {
+interface FormLabelDescriptionProps extends TextProps, WithSsr {
   useMarkdown?: boolean
   children: string
 }
 const FormLabelDescription = ({
   children,
   useMarkdown = false,
+  ssr,
   ...props
 }: FormLabelDescriptionProps): JSX.Element => {
   // useFormControlContext is a ChakraUI hook that returns props passed down
@@ -133,6 +139,7 @@ const FormLabelDescription = ({
     link: { display: 'initial' },
   }
   const mdComponents = useMdComponents({
+    ssr,
     styles: mdComponentsStyles,
     overrides: {
       p: (props) => (

--- a/react/src/FormControl/FormLabel/FormLabel.tsx
+++ b/react/src/FormControl/FormLabel/FormLabel.tsx
@@ -15,9 +15,11 @@ import {
 import { useMdComponents } from '~/hooks/useMdComponents'
 import { BxsHelpCircle } from '~/icons/BxsHelpCircle'
 import { Tooltip } from '~/Tooltip'
-import type { WithSsr } from '~/types/WithSsr'
+import type { WithReactMarkdownSsr } from '~/types/WithSsr'
 
-export interface FormLabelProps extends ChakraFormLabelProps, WithSsr {
+export interface FormLabelProps
+  extends ChakraFormLabelProps,
+    WithReactMarkdownSsr {
   /**
    * Question number to be prefixed before each label, if any.
    */
@@ -63,6 +65,7 @@ export const FormLabel = ({
   useMarkdownForDescription = false,
   children,
   ssr,
+  mdIsExternalLinkFn,
   ...labelProps
 }: FormLabelProps): JSX.Element => {
   return (
@@ -92,6 +95,7 @@ export const FormLabel = ({
       {description && (
         <FormLabel.Description
           ssr={ssr}
+          mdIsExternalLinkFn={mdIsExternalLinkFn}
           useMarkdown={useMarkdownForDescription}
         >
           {description}
@@ -103,7 +107,7 @@ export const FormLabel = ({
 
 FormLabel.Label = ChakraFormLabel
 
-interface FormLabelDescriptionProps extends TextProps, WithSsr {
+interface FormLabelDescriptionProps extends TextProps, WithReactMarkdownSsr {
   useMarkdown?: boolean
   children: string
 }
@@ -111,6 +115,7 @@ const FormLabelDescription = ({
   children,
   useMarkdown = false,
   ssr,
+  mdIsExternalLinkFn,
   ...props
 }: FormLabelDescriptionProps): JSX.Element => {
   // useFormControlContext is a ChakraUI hook that returns props passed down
@@ -141,6 +146,11 @@ const FormLabelDescription = ({
   const mdComponents = useMdComponents({
     ssr,
     styles: mdComponentsStyles,
+    props: {
+      link: {
+        isExternalFn: mdIsExternalLinkFn,
+      },
+    },
     overrides: {
       p: (props) => (
         <ComponentToRender {...props} sx={mdComponentsStyles.text} />

--- a/react/src/Infobox/Infobox.tsx
+++ b/react/src/Infobox/Infobox.tsx
@@ -12,8 +12,9 @@ import {
 import { useMdComponents } from '~/hooks/useMdComponents'
 import { BxsErrorCircle, BxsInfoCircle } from '~/icons'
 import { InfoboxVariant } from '~/theme/components/Infobox'
+import type { WithSsr } from '~/types/WithSsr'
 
-export interface InfoboxProps extends FlexProps {
+export interface InfoboxProps extends FlexProps, WithSsr {
   size?: ThemingProps<'Infobox'>['size']
   variant?: InfoboxVariant
   /**
@@ -39,12 +40,13 @@ export const Infobox = ({
   useMarkdown = false,
   icon: iconProp,
   size,
+  ssr,
   ...flexProps
 }: InfoboxProps): JSX.Element => {
   const styles = useMultiStyleConfig('Infobox', { variant, size })
 
   const mdComponents = useMdComponents({
-    styles,
+    ssr,
     props: {
       link: {
         colorScheme: 'neutral',

--- a/react/src/Infobox/Infobox.tsx
+++ b/react/src/Infobox/Infobox.tsx
@@ -12,9 +12,9 @@ import {
 import { useMdComponents } from '~/hooks/useMdComponents'
 import { BxsErrorCircle, BxsInfoCircle } from '~/icons'
 import { InfoboxVariant } from '~/theme/components/Infobox'
-import type { WithSsr } from '~/types/WithSsr'
+import type { WithReactMarkdownSsr } from '~/types/WithSsr'
 
-export interface InfoboxProps extends FlexProps, WithSsr {
+export interface InfoboxProps extends FlexProps, WithReactMarkdownSsr {
   size?: ThemingProps<'Infobox'>['size']
   variant?: InfoboxVariant
   /**
@@ -41,6 +41,7 @@ export const Infobox = ({
   icon: iconProp,
   size,
   ssr,
+  mdIsExternalLinkFn,
   ...flexProps
 }: InfoboxProps): JSX.Element => {
   const styles = useMultiStyleConfig('Infobox', { variant, size })
@@ -50,6 +51,7 @@ export const Infobox = ({
     props: {
       link: {
         colorScheme: 'neutral',
+        isExternalFn: mdIsExternalLinkFn,
       },
     },
   })

--- a/react/src/Toast/Toast.tsx
+++ b/react/src/Toast/Toast.tsx
@@ -14,17 +14,15 @@ import {
 
 import { useMdComponents } from '~/hooks/useMdComponents'
 import { BxsCheckCircle, BxsErrorCircle, BxsInfoCircle, BxX } from '~/icons'
+import type { WithSsr } from '~/types/WithSsr'
 
 import { SpinnerIcon } from '..'
-
 // Alias for convenience
 export type ToastStatus = AlertStatus
 
 export interface ToastProps
-  extends Omit<
-    UseToastOptions,
-    'duration' | 'position' | 'render' | 'variant'
-  > {
+  extends Omit<UseToastOptions, 'duration' | 'position' | 'render' | 'variant'>,
+    WithSsr {
   /**
    * RenderProps that chakra passes to all custom components that uses the
    * render function
@@ -62,6 +60,7 @@ export const Toast = ({
   isClosable,
   onClose,
   onCloseComplete,
+  ssr,
   ...toastStyleProps
 }: ToastProps): JSX.Element => {
   const styles = useMultiStyleConfig('Toast', {
@@ -73,7 +72,7 @@ export const Toast = ({
     return STATUS_TO_ICON[status]
   }, [status])
 
-  const mdComponents = useMdComponents(styles)
+  const mdComponents = useMdComponents({ ssr })
 
   const descriptionComponent = useMemo(() => {
     // ReactMarkdown requires children to be of string type. If description is

--- a/react/src/Toast/Toast.tsx
+++ b/react/src/Toast/Toast.tsx
@@ -14,7 +14,7 @@ import {
 
 import { useMdComponents } from '~/hooks/useMdComponents'
 import { BxsCheckCircle, BxsErrorCircle, BxsInfoCircle, BxX } from '~/icons'
-import type { WithSsr } from '~/types/WithSsr'
+import type { WithReactMarkdownSsr } from '~/types/WithSsr'
 
 import { SpinnerIcon } from '..'
 // Alias for convenience
@@ -22,7 +22,7 @@ export type ToastStatus = AlertStatus
 
 export interface ToastProps
   extends Omit<UseToastOptions, 'duration' | 'position' | 'render' | 'variant'>,
-    WithSsr {
+    WithReactMarkdownSsr {
   /**
    * RenderProps that chakra passes to all custom components that uses the
    * render function
@@ -61,6 +61,7 @@ export const Toast = ({
   onClose,
   onCloseComplete,
   ssr,
+  mdIsExternalLinkFn,
   ...toastStyleProps
 }: ToastProps): JSX.Element => {
   const styles = useMultiStyleConfig('Toast', {
@@ -72,7 +73,14 @@ export const Toast = ({
     return STATUS_TO_ICON[status]
   }, [status])
 
-  const mdComponents = useMdComponents({ ssr })
+  const mdComponents = useMdComponents({
+    ssr,
+    props: {
+      link: {
+        isExternalFn: mdIsExternalLinkFn,
+      },
+    },
+  })
 
   const descriptionComponent = useMemo(() => {
     // ReactMarkdown requires children to be of string type. If description is

--- a/react/src/Toast/useToast.ts
+++ b/react/src/Toast/useToast.ts
@@ -2,17 +2,22 @@ import { createElement } from 'react'
 import {
   CreateToastFnReturn,
   useToast as useChakraToast,
-  UseToastOptions,
+  UseToastOptions as ChakraUseToastOptions,
 } from '@chakra-ui/react'
 import { omit } from 'lodash'
 
+import type { WithSsr } from '~/types/WithSsr'
+
 import { Toast } from './Toast'
+
+interface UseToastOptions extends ChakraUseToastOptions, WithSsr {}
 
 export const useToast = ({
   status = 'success',
   duration = 6000,
   position = 'top',
   containerStyle: containerStyleProps,
+  ssr,
   ...initialProps
 }: UseToastOptions = {}): CreateToastFnReturn => {
   const initialToastProps = omit(initialProps, ['onClose', 'status'])
@@ -27,7 +32,7 @@ export const useToast = ({
     duration,
     position,
     render: (props) => {
-      return createElement(Toast, props)
+      return createElement(Toast, { ...props, ssr })
     },
   })
 }

--- a/react/src/Toast/useToast.ts
+++ b/react/src/Toast/useToast.ts
@@ -6,11 +6,11 @@ import {
 } from '@chakra-ui/react'
 import { omit } from 'lodash'
 
-import type { WithSsr } from '~/types/WithSsr'
+import type { WithReactMarkdownSsr } from '~/types/WithSsr'
 
 import { Toast } from './Toast'
 
-interface UseToastOptions extends ChakraUseToastOptions, WithSsr {}
+interface UseToastOptions extends ChakraUseToastOptions, WithReactMarkdownSsr {}
 
 export const useToast = ({
   status = 'success',
@@ -18,6 +18,7 @@ export const useToast = ({
   position = 'top',
   containerStyle: containerStyleProps,
   ssr,
+  mdIsExternalLinkFn,
   ...initialProps
 }: UseToastOptions = {}): CreateToastFnReturn => {
   const initialToastProps = omit(initialProps, ['onClose', 'status'])
@@ -32,7 +33,7 @@ export const useToast = ({
     duration,
     position,
     render: (props) => {
-      return createElement(Toast, { ...props, ssr })
+      return createElement(Toast, { ...props, ssr, mdIsExternalLinkFn })
     },
   })
 }

--- a/react/src/types/WithSsr.ts
+++ b/react/src/types/WithSsr.ts
@@ -6,3 +6,24 @@ export type WithSsr = {
    */
   ssr?: boolean
 }
+
+export interface WithReactMarkdownSsr extends WithSsr {
+  /**
+   * If provided, will be used to determine if links created from markdown are external links.
+   * @example
+   * ```tsx
+   * const isExternal = (url: string) => {
+   *   try {
+   *     const parsed = new URL(url)
+   *     // if in a non-ssr environment, you can use window.location.hostname
+   *     return parsed.hostname !== 'window.location.hostname'
+   *     // If in a SSR environment, you can use the request object
+   *     // return parsed.hostname !== req.hostname
+   *   } catch (e) {
+   *     return false
+   *   }
+   * }
+   * ```
+   */
+  mdIsExternalLinkFn?: (url: string) => boolean
+}


### PR DESCRIPTION
## Problem

When `useMdComponent` is used in an SSR environment, a hydration mismatch will occur due to the use of `window.location` when checking whether links are external.

This commit adds the `ssr` and `link.isExternalFn` prop for use in SSR environment to prevent a hydration mismatch. However, external icons will no longer render and there is a need to use the `link.isExternalFn` fn to calculate external-ness in an ssr environment.

