### PR TITLE
feat: add onChange prop to searchbar to enable dynamic search

### DIFF
--- a/react/src/Searchbar/Searchbar.tsx
+++ b/react/src/Searchbar/Searchbar.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent, useCallback, useRef } from 'react'
+import { ChangeEvent, KeyboardEvent, useCallback, useRef } from 'react'
 import {
   Box,
   forwardRef,
@@ -16,12 +16,18 @@ import {
 import { IconButton } from '~/IconButton'
 import { BxSearch, BxX } from '~/icons'
 
-export interface SearchbarProps extends InputProps {
+export interface SearchbarProps extends Omit<InputProps, 'onChange'> {
   /**
    * Function to be invoked when user presses enter (to search).
    * @param searchValue value of the search input
    */
-  onSearch: (searchValue: string) => void
+  onSearch?: (searchValue: string) => void
+
+  /**
+   * Function to be invoked when the search input has changed.
+   * @param searchValue value of the search input
+   */
+  onChange?: (searchValue: string) => void
 
   /**
    * Whether the searchbar is expanded or not by default.
@@ -67,6 +73,7 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
   (
     {
       onSearch,
+      onChange,
       defaultIsExpanded,
       isExpanded: isExpandedProp,
       onExpansion: onExpansionProp,
@@ -95,8 +102,17 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
 
     const handleSearch = useCallback(
       (e: KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter' && innerRef.current) {
+        if (e.key === 'Enter' && innerRef.current && onSearch) {
           onSearch(innerRef.current.value)
+        }
+      },
+      [onSearch],
+    )
+
+    const handleChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        if (onChange) {
+          onChange(e.currentTarget.value)
         }
       },
       [onSearch],
@@ -146,6 +162,7 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
           ref={inputRef}
           sx={styles.field}
           onKeyDown={handleSearch}
+          onChange={handleChange}
           {...props}
         />
         {showClearButton && isExpanded && (

--- a/react/src/Searchbar/Searchbar.tsx
+++ b/react/src/Searchbar/Searchbar.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, KeyboardEvent, useCallback, useRef } from 'react'
+import { KeyboardEvent, useCallback, useRef } from 'react'
 import {
   Box,
   forwardRef,
@@ -16,18 +16,12 @@ import {
 import { IconButton } from '~/IconButton'
 import { BxSearch, BxX } from '~/icons'
 
-export interface SearchbarProps extends Omit<InputProps, 'onChange'> {
+export interface SearchbarProps extends InputProps {
   /**
    * Function to be invoked when user presses enter (to search).
    * @param searchValue value of the search input
    */
   onSearch?: (searchValue: string) => void
-
-  /**
-   * Function to be invoked when the search input has changed.
-   * @param searchValue value of the search input
-   */
-  onChange?: (searchValue: string) => void
 
   /**
    * Whether the searchbar is expanded or not by default.
@@ -73,7 +67,6 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
   (
     {
       onSearch,
-      onChange,
       defaultIsExpanded,
       isExpanded: isExpandedProp,
       onExpansion: onExpansionProp,
@@ -104,15 +97,6 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
       (e: KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter' && innerRef.current && onSearch) {
           onSearch(innerRef.current.value)
-        }
-      },
-      [onSearch],
-    )
-
-    const handleChange = useCallback(
-      (e: ChangeEvent<HTMLInputElement>) => {
-        if (onChange) {
-          onChange(e.currentTarget.value)
         }
       },
       [onSearch],
@@ -162,7 +146,6 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
           ref={inputRef}
           sx={styles.field}
           onKeyDown={handleSearch}
-          onChange={handleChange}
           {...props}
         />
         {showClearButton && isExpanded && (


### PR DESCRIPTION
## Problem

Some projects want to implement dynamic searches using design system (i.e. searching on change rather than on keydown Enter), but right now it's a bit clunky. The current workaround is to do this:

```javascript
const Component = () => {
  const handleSearch = (searchterm: string) => { return stuff }
  // Other stuff here
  return (
    <Searchbar 
      onChange = {(e) => handleSearch(e.currentTarget.value)} 
      onSearch = {handleSearch} // Actually not required
    />
  )
}
```
## Solution

Make `onSearch` optional, and add an optional `onChange` prop. This means that users may choose one or the other, and will not be required to implement both.

Since there's a change to the type of `onChange`, this might be breaking for some people.

Feel free to close if unwanted though