### PR TITLE
fix(menu): add `mt` for menu item

### DIFF
--- a/react/src/theme/components/Menu.ts
+++ b/react/src/theme/components/Menu.ts
@@ -46,6 +46,7 @@ const baseStyle = definePartsStyle((props) => {
       boxShadow: $shadow.reference,
     },
     item: {
+      mt: '0.125rem',
       bg: $bg.reference,
       textStyle: 'body-1',
       fontWeight: '400',

--- a/react/src/theme/components/Menu.ts
+++ b/react/src/theme/components/Menu.ts
@@ -4,6 +4,11 @@ import { StyleFunctionProps } from '@chakra-ui/theme-tools'
 
 const parts = menuAnatomy.extend('chevron')
 
+const MENU_ITEM_BORDER_STYLES = {
+  mt: '2px',
+  outlineOffset: '-2px',
+}
+
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
@@ -46,7 +51,6 @@ const baseStyle = definePartsStyle((props) => {
       boxShadow: $shadow.reference,
     },
     item: {
-      mt: '0.125rem',
       bg: $bg.reference,
       textStyle: 'body-1',
       fontWeight: '400',
@@ -109,6 +113,7 @@ const getClearButtonColors = ({ colorScheme: c }: StyleFunctionProps) => {
 const variantClear = definePartsStyle((props) => {
   const { color, hoverColor, activeColor } = getClearButtonColors(props)
   return {
+    item: MENU_ITEM_BORDER_STYLES,
     button: {
       bg: 'transparent',
       color,
@@ -124,7 +129,7 @@ const variantClear = definePartsStyle((props) => {
 
 const variants = {
   clear: variantClear,
-  outline: {},
+  outline: { item: MENU_ITEM_BORDER_STYLES },
 }
 
 const sizes = {


### PR DESCRIPTION
## Problem
See #188. This problem is because css sizing doesn't account for `boxShadow` (as we aren't using `border`)

Closes #188

## Solution
1. Add `mt` which is equal to the size of the box shadow.
    - i'm not entirely sure if this is the best way to do it, but it was a simple + straight forward way for this