### PR TITLE
fix: add outline offset to default link styles

### DIFF
--- a/react/src/theme/components/Link.ts
+++ b/react/src/theme/components/Link.ts
@@ -43,6 +43,7 @@ const baseStyle = defineStyle((props) => {
   const { color, hoverColor } = getLinkColors(props)
 
   return {
+    outlineOffset: 0,
     height: 'fit-content',
     width: 'fit-content',
     position: 'relative',


### PR DESCRIPTION
when removing focus on links, there would be a wonky focus ring expansion animation due to outline offset changing from 0 to 2px. Setting the offset on the root style stops that from happening
