### PR TITLE
fix: date picker calendar select correct date in negative UTC offset timezones

### DIFF
--- a/react/src/DatePicker/DatePickerContext.tsx
+++ b/react/src/DatePicker/DatePickerContext.tsx
@@ -84,7 +84,7 @@ const useProvideDatePicker = ({
   isReadOnly: isReadOnlyProp,
   isRequired: isRequiredProp,
   isInvalid: isInvalidProp,
-  timeZone = 'UTC',
+  timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
   locale,
   isDateUnavailable,
   allowManualInput = true,


### PR DESCRIPTION
## Problem

Similar issue discovered in Form where selecting a date using date picker in negative UTC offset timezones will result in the the day before being selected.

## Solution
Same solution as the PR in Form https://github.com/opengovsg/FormSG/pull/5731/. 
Would like to reiterate that this might not be the most comprehensive solution but it appears to at least fix the issue for the time being. 


