### PR TITLE
feat(components): add `ProgressIndicator`

### DIFF
--- a/react/src/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/react/src/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import {
+  getMobileViewParameters,
+  getTabletViewParameters,
+} from '~/utils/storybook'
+
+import { ProgressIndicator, ProgressIndicatorProps } from './ProgressIndicator'
+
+const DEFAULT_ARGS = {
+  numIndicators: 2,
+  currActiveIdx: 0,
+}
+
+export default {
+  title: 'Components/ProgressIndicator',
+  component: ProgressIndicator,
+  tags: ['autodocs'],
+} as Meta<ProgressIndicatorProps>
+
+const Template: StoryFn<ProgressIndicatorProps> = ({
+  numIndicators,
+  currActiveIdx,
+}) => {
+  const [activeIdx, setActiveIdx] = useState(currActiveIdx)
+  return (
+    <ProgressIndicator
+      numIndicators={numIndicators}
+      currActiveIdx={activeIdx}
+      onClick={(selected) => setActiveIdx(selected)}
+    />
+  )
+}
+export const Default = Template.bind({})
+Default.args = DEFAULT_ARGS
+export const Mobile = Template.bind({})
+Mobile.args = DEFAULT_ARGS
+Mobile.parameters = getMobileViewParameters()
+
+export const Tablet = Template.bind({})
+Tablet.args = DEFAULT_ARGS
+Tablet.parameters = getTabletViewParameters()

--- a/react/src/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/react/src/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
+import { DarkMode } from '@chakra-ui/react'
 import { Meta, StoryFn } from '@storybook/react'
 
 import {
@@ -19,21 +20,37 @@ export default {
   tags: ['autodocs'],
 } as Meta<ProgressIndicatorProps>
 
-const Template: StoryFn<ProgressIndicatorProps> = ({
+interface TemplateProps extends ProgressIndicatorProps {
+  colorMode: 'light' | 'dark'
+}
+
+const Template: StoryFn<TemplateProps> = ({
+  colorMode,
   numIndicators,
   currActiveIdx,
 }) => {
   const [activeIdx, setActiveIdx] = useState(currActiveIdx)
+  const ColorModeWrapper = useMemo(() => {
+    if (colorMode === 'dark') {
+      return DarkMode
+    }
+    return Fragment
+  }, [colorMode])
+
   return (
-    <ProgressIndicator
-      numIndicators={numIndicators}
-      currActiveIdx={activeIdx}
-      onClick={(selected) => setActiveIdx(selected)}
-    />
+    <ColorModeWrapper>
+      <ProgressIndicator
+        numIndicators={numIndicators}
+        currActiveIdx={activeIdx}
+        onClick={(selected) => setActiveIdx(selected)}
+      />
+    </ColorModeWrapper>
   )
 }
+
 export const Default = Template.bind({})
 Default.args = DEFAULT_ARGS
+
 export const Mobile = Template.bind({})
 Mobile.args = DEFAULT_ARGS
 Mobile.parameters = getMobileViewParameters()
@@ -41,3 +58,9 @@ Mobile.parameters = getMobileViewParameters()
 export const Tablet = Template.bind({})
 Tablet.args = DEFAULT_ARGS
 Tablet.parameters = getTabletViewParameters()
+
+export const DefaultDark = Template.bind({})
+DefaultDark.args = { colorMode: 'dark', ...DEFAULT_ARGS }
+DefaultDark.parameters = {
+  backgrounds: { default: 'dark' },
+}

--- a/react/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/react/src/ProgressIndicator/ProgressIndicator.tsx
@@ -1,19 +1,12 @@
 import { useMemo } from 'react'
-import { Box, BoxProps } from '@chakra-ui/react'
+import { Box, BoxProps, useMultiStyleConfig } from '@chakra-ui/react'
 
 import { MotionBox } from '../motion'
 
-const ActiveIndicator = (): JSX.Element => (
-  <Box
-    // Top required to align it with CircleIndicators
-    top="0.125rem"
-    width="1.5rem"
-    height="0.5rem"
-    borderRadius="full"
-    backgroundColor="interaction.support.selected"
-    position="absolute"
-  />
-)
+const ActiveIndicator = (): JSX.Element => {
+  const styles = useMultiStyleConfig('ProgressIndicator')
+  return <Box __css={styles.activeIndicator} />
+}
 
 interface CircleIndicatorProps extends BoxProps {
   onClick: () => void
@@ -25,14 +18,10 @@ const CircleIndicator = ({
   isActiveIndicator,
   ...props
 }: CircleIndicatorProps): JSX.Element => {
+  const styles = useMultiStyleConfig('ProgressIndicator', { isActiveIndicator })
   return (
     <Box
-      width="0.75rem"
-      height="0.75rem"
-      padding="0.125rem"
-      borderRadius="full"
-      backgroundColor="interaction.support.unselected"
-      marginRight={isActiveIndicator ? '1.25rem' : '0.25rem'}
+      __css={styles.circleIndicator}
       onClick={onClick}
       _hover={{ backgroundColor: 'secondary.300' }}
       _focus={
@@ -43,7 +32,6 @@ const CircleIndicator = ({
               boxShadow: `0 0 0 1px var(--chakra-colors-secondary-400)`,
             }
       }
-      backgroundClip="content-box"
       as="button"
       {...props}
     />
@@ -71,6 +59,8 @@ export const ProgressIndicator = ({
   currActiveIdx,
   onClick,
 }: ProgressIndicatorProps): JSX.Element => {
+  const styles = useMultiStyleConfig('ProgressIndicator')
+
   const indicators = useMemo(
     () => Array(numIndicators).fill(1),
     [numIndicators],
@@ -81,7 +71,7 @@ export const ProgressIndicator = ({
   }, [currActiveIdx])
 
   return (
-    <Box display="inline-flex" alignSelf="center">
+    <Box __css={styles.container}>
       {indicators.map((_, idx) => (
         <CircleIndicator
           key={idx}

--- a/react/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/react/src/ProgressIndicator/ProgressIndicator.tsx
@@ -10,7 +10,7 @@ const ActiveIndicator = (): JSX.Element => (
     width="1.5rem"
     height="0.5rem"
     borderRadius="full"
-    backgroundColor="secondary.500"
+    backgroundColor="interaction.support.selected"
     position="absolute"
   />
 )
@@ -31,7 +31,7 @@ const CircleIndicator = ({
       height="0.75rem"
       padding="0.125rem"
       borderRadius="full"
-      backgroundColor="secondary.200"
+      backgroundColor="interaction.support.unselected"
       marginRight={isActiveIndicator ? '1.25rem' : '0.25rem'}
       onClick={onClick}
       _hover={{ backgroundColor: 'secondary.300' }}
@@ -50,9 +50,19 @@ const CircleIndicator = ({
   )
 }
 
-interface ProgressIndicatorProps {
+export interface ProgressIndicatorProps {
+  /**
+   * The number of indicators to display
+   */
   numIndicators: number
+  /**
+   * The current active indicator, this will be longer
+   */
   currActiveIdx: number
+  /**
+   * Action to take when the indicator is clicked
+   * @param indicatorIdx The indicator that was clicked
+   */
   onClick: (indicatorIdx: number) => void
 }
 

--- a/react/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/react/src/ProgressIndicator/ProgressIndicator.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react'
+import { Box, BoxProps } from '@chakra-ui/react'
+
+import { MotionBox } from '../motion'
+
+const ActiveIndicator = (): JSX.Element => (
+  <Box
+    // Top required to align it with CircleIndicators
+    top="0.125rem"
+    width="1.5rem"
+    height="0.5rem"
+    borderRadius="full"
+    backgroundColor="secondary.500"
+    position="absolute"
+  />
+)
+
+interface CircleIndicatorProps extends BoxProps {
+  onClick: () => void
+  isActiveIndicator: boolean
+}
+
+const CircleIndicator = ({
+  onClick,
+  isActiveIndicator,
+  ...props
+}: CircleIndicatorProps): JSX.Element => {
+  return (
+    <Box
+      width="0.75rem"
+      height="0.75rem"
+      padding="0.125rem"
+      borderRadius="full"
+      backgroundColor="secondary.200"
+      marginRight={isActiveIndicator ? '1.25rem' : '0.25rem'}
+      onClick={onClick}
+      _hover={{ backgroundColor: 'secondary.300' }}
+      _focus={
+        isActiveIndicator
+          ? undefined
+          : {
+              backgroundColor: 'secondary.300',
+              boxShadow: `0 0 0 1px var(--chakra-colors-secondary-400)`,
+            }
+      }
+      backgroundClip="content-box"
+      as="button"
+      {...props}
+    />
+  )
+}
+
+interface ProgressIndicatorProps {
+  numIndicators: number
+  currActiveIdx: number
+  onClick: (indicatorIdx: number) => void
+}
+
+export const ProgressIndicator = ({
+  numIndicators,
+  currActiveIdx,
+  onClick,
+}: ProgressIndicatorProps): JSX.Element => {
+  const indicators = useMemo(
+    () => Array(numIndicators).fill(1),
+    [numIndicators],
+  )
+
+  const animationProps = useMemo(() => {
+    return { x: `${currActiveIdx + 0.125}rem` }
+  }, [currActiveIdx])
+
+  return (
+    <Box display="inline-flex" alignSelf="center">
+      {indicators.map((_, idx) => (
+        <CircleIndicator
+          key={idx}
+          isActiveIndicator={idx === currActiveIdx}
+          onClick={() => onClick(idx)}
+          aria-label={`Page ${idx + 1} of ${numIndicators}`}
+        />
+      ))}
+
+      <MotionBox
+        // Absolute positioning is required for the active progress indicator to slide over inactive ones
+        pos="absolute"
+        animate={animationProps}
+        transition={{ stiffness: 100 }}
+      >
+        <ActiveIndicator />
+      </MotionBox>
+    </Box>
+  )
+}

--- a/react/src/ProgressIndicator/index.ts
+++ b/react/src/ProgressIndicator/index.ts
@@ -1,0 +1,1 @@
+export * from './ProgressIndicator'

--- a/react/src/motion/MotionBox.tsx
+++ b/react/src/motion/MotionBox.tsx
@@ -1,0 +1,7 @@
+import { FC } from 'react'
+import { Box, BoxProps } from '@chakra-ui/react'
+import { HTMLMotionProps, motion } from 'framer-motion'
+import { Merge } from 'type-fest'
+
+export type MotionBoxProps = Merge<BoxProps, HTMLMotionProps<'div'>>
+export const MotionBox: FC<MotionBoxProps> = motion(Box)

--- a/react/src/motion/index.ts
+++ b/react/src/motion/index.ts
@@ -1,0 +1,1 @@
+export * from './MotionBox'

--- a/react/src/theme/components/ProgressIndicator.ts
+++ b/react/src/theme/components/ProgressIndicator.ts
@@ -1,0 +1,40 @@
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
+import { anatomy } from '@chakra-ui/theme-tools'
+
+const parts = anatomy('attachment').parts(
+  'circleIndicator',
+  'activeIndicator',
+  'container',
+)
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(parts.keys)
+
+const baseStyle = definePartsStyle(({ isActiveIndicator, colorMode }) => ({
+  circleIndicator: {
+    width: '0.75rem',
+    height: '0.75rem',
+    padding: '0.125rem',
+    borderRadius: 'full',
+    backgroundColor: 'interaction.support.unselected',
+    mr: isActiveIndicator ? '1.25rem' : '0.25rem',
+    backgroundClip: 'content-box',
+  },
+  activeIndicator: {
+    // Top required to align it with CircleIndicators
+    top: '0.125rem',
+    width: '1.5rem',
+    height: '0.5rem',
+    borderRadius: 'full',
+    backgroundColor:
+      colorMode === 'light'
+        ? 'interaction.support.selected'
+        : 'base.content.inverse',
+    position: 'absolute',
+  },
+  container: { display: 'inline-flex', alignSelf: 'center' },
+}))
+
+export const ProgressIndicator = defineMultiStyleConfig({
+  baseStyle,
+})

--- a/react/src/theme/components/index.ts
+++ b/react/src/theme/components/index.ts
@@ -26,6 +26,7 @@ import { NumberInput } from './NumberInput'
 import { Pagination } from './Pagination'
 import { PhoneNumberInput } from './PhoneNumberInput'
 import { Progress } from './Progress'
+import { ProgressIndicator } from './ProgressIndicator'
 import { Radio } from './Radio'
 import { Searchbar } from './Searchbar'
 import { SingleCountryPhoneNumberInput } from './SingleCountryPhoneNumberInput'
@@ -69,6 +70,7 @@ export const components = {
   Pagination,
   PhoneNumberInput,
   Progress,
+  ProgressIndicator,
   Radio,
   Searchbar,
   SingleCountryPhoneNumberInput,

--- a/react/src/theme/theme.ts
+++ b/react/src/theme/theme.ts
@@ -11,6 +11,10 @@ import { layerStyles } from './layerStyles'
 import { textStyles } from './textStyles'
 
 export const theme = extendTheme({
+  config: {
+    initialColorMode: 'light',
+    useSystemColorMode: false,
+  },
   styles: {
     global: {
       body: {


### PR DESCRIPTION
## Problem
Design system has a progress indicator, which is not yet implemented (but is done so in forms). This PR ports and adapts the progress indicator over.

**note:** hover/progress states waiting for designer, will edit to use design tokens once done.

## Solution
Port over `ProgressIndicator` from forms, edit to use design tokens, shift styling to `themes` file. Note that the current implementation of our `ColorMode` **does not** actually work with the `useColorMode` hook, as it hooks into a different `Provider`.  the `useColorMode` hook uses a different provider (see [here](https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/color-mode/src/color-mode-context.ts)) than the `ColorModeProvider` (see [here](https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/color-mode/src/color-mode-provider.tsx)).