### PR TITLE
fix: upgrade downshift from 6.1.12 to 7.2.0, a11y fixes for single select and multiselect

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -16,7 +16,7 @@
         "date-fns": "^2.28.0",
         "date-fns-tz": "^2.0.0",
         "dayzed": "^3.2.3",
-        "downshift": "^6.1.7",
+        "downshift": "^7.2.0",
         "fuzzysort": "^2.0.1",
         "inter-ui": "^3.19.3",
         "libphonenumber-js": "^1.9.44",
@@ -16502,7 +16502,8 @@
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -17068,12 +17069,12 @@
       "dev": true
     },
     "node_modules/downshift": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
-      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.2.0.tgz",
+      "integrity": "sha512-dEn1Sshe7iTelUhmdbmiJhtIiwIBxBV8p15PuvEBh0qZcHXZnEt0geuCIIkCL4+ooaKRuLE0Wc+Fz9SwWuBIyg==",
       "dependencies": {
         "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^1.0.17",
+        "compute-scroll-into-view": "^2.0.4",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2",
         "tslib": "^2.3.0"
@@ -17081,6 +17082,11 @@
       "peerDependencies": {
         "react": ">=16.12.0"
       }
+    },
+    "node_modules/downshift/node_modules/compute-scroll-into-view": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
+      "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
     },
     "node_modules/duplexer3": {
       "version": "0.1.5",
@@ -37093,7 +37099,8 @@
     "compute-scroll-into-view": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
+      "peer": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -37533,15 +37540,22 @@
       "dev": true
     },
     "downshift": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
-      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.2.0.tgz",
+      "integrity": "sha512-dEn1Sshe7iTelUhmdbmiJhtIiwIBxBV8p15PuvEBh0qZcHXZnEt0geuCIIkCL4+ooaKRuLE0Wc+Fz9SwWuBIyg==",
       "requires": {
         "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^1.0.17",
+        "compute-scroll-into-view": "^2.0.4",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "compute-scroll-into-view": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
+          "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
+        }
       }
     },
     "duplexer3": {

--- a/react/package.json
+++ b/react/package.json
@@ -40,7 +40,7 @@
     "date-fns": "^2.28.0",
     "date-fns-tz": "^2.0.0",
     "dayzed": "^3.2.3",
-    "downshift": "^6.1.7",
+    "downshift": "^7.2.0",
     "fuzzysort": "^2.0.1",
     "inter-ui": "^3.19.3",
     "libphonenumber-js": "^1.9.44",

--- a/react/src/MultiSelect/MultiSelectProvider.tsx
+++ b/react/src/MultiSelect/MultiSelectProvider.tsx
@@ -86,7 +86,7 @@ export const MultiSelectProvider = ({
   maxItems = 4,
   downshiftComboboxProps = {},
   downshiftMultiSelectProps = {},
-  inputAria: inputAriaProp,
+  inputAria,
   children,
   size = 'md',
   colorScheme,
@@ -176,7 +176,6 @@ export const MultiSelectProvider = ({
     closeMenu,
     isOpen,
     getLabelProps,
-    getComboboxProps,
     getMenuProps,
     getInputProps,
     getItemProps,
@@ -247,8 +246,14 @@ export const MultiSelectProvider = ({
             inputValue: '',
             isOpen: false,
           }
+        case useCombobox.stateChangeTypes.InputFocus:
+          return {
+            ...changes,
+            isOpen: false, // keep the menu closed when input gets focused.
+          }
+        default:
+          return changes
       }
-      return changes
     },
     ...downshiftComboboxProps,
   })
@@ -266,20 +271,6 @@ export const MultiSelectProvider = ({
     },
     [selectedItems],
   )
-
-  const inputAria = useMemo(() => {
-    if (inputAriaProp) return inputAriaProp
-    let label = 'No options selected'
-    if (selectedItems.length > 0) {
-      label = `Options ${selectedItems
-        .map((i) => itemToValue(i))
-        .join(',')}, selected`
-    }
-    return {
-      id: `${name}-current-selection`,
-      label,
-    }
-  }, [inputAriaProp, name, selectedItems])
 
   const styles = useMultiStyleConfig('MultiSelect', {
     size,
@@ -305,7 +296,6 @@ export const MultiSelectProvider = ({
         isItemSelected,
         toggleMenu,
         closeMenu,
-        getComboboxProps,
         getInputProps,
         getItemProps,
         getLabelProps,

--- a/react/src/MultiSelect/MultiSelectProvider.tsx
+++ b/react/src/MultiSelect/MultiSelectProvider.tsx
@@ -251,6 +251,11 @@ export const MultiSelectProvider = ({
             ...changes,
             isOpen: false, // keep the menu closed when input gets focused.
           }
+        case useCombobox.stateChangeTypes.ToggleButtonClick:
+          return {
+            ...changes,
+            isOpen: !state.isOpen,
+          }
         default:
           return changes
       }

--- a/react/src/MultiSelect/components/MultiDropdownItem/MultiDropdownItem.tsx
+++ b/react/src/MultiSelect/components/MultiDropdownItem/MultiDropdownItem.tsx
@@ -7,7 +7,6 @@ import {
   Text,
   VisuallyHidden,
 } from '@chakra-ui/react'
-import { dataAttr } from '@chakra-ui/utils'
 
 import type { ComboboxItem } from '~/SingleSelect'
 import { useSelectContext } from '~/SingleSelect'
@@ -47,7 +46,6 @@ export const MultiDropdownItem = ({
   return (
     <ListItem
       sx={styles.item}
-      data-active={dataAttr(isSelected)}
       {...getItemProps({
         item,
         index,

--- a/react/src/MultiSelect/components/MultiDropdownItem/MultiDropdownItem.tsx
+++ b/react/src/MultiSelect/components/MultiDropdownItem/MultiDropdownItem.tsx
@@ -1,5 +1,13 @@
 import { useMemo } from 'react'
-import { Flex, Icon, ListItem, Stack, Text } from '@chakra-ui/react'
+import {
+  Flex,
+  Icon,
+  ListItem,
+  Stack,
+  Text,
+  VisuallyHidden,
+} from '@chakra-ui/react'
+import { dataAttr } from '@chakra-ui/utils'
 
 import type { ComboboxItem } from '~/SingleSelect'
 import { useSelectContext } from '~/SingleSelect'
@@ -39,6 +47,7 @@ export const MultiDropdownItem = ({
   return (
     <ListItem
       sx={styles.item}
+      data-active={dataAttr(isSelected)}
       {...getItemProps({
         item,
         index,
@@ -74,6 +83,9 @@ export const MultiDropdownItem = ({
                 textToHighlight={description}
               />
             </Text>
+          )}
+          {isSelected && (
+            <VisuallyHidden aria-live="assertive">, selected</VisuallyHidden>
           )}
         </Flex>
       </Stack>

--- a/react/src/MultiSelect/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/react/src/MultiSelect/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -27,6 +27,7 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
       toggleMenu,
       isInvalid,
       inputRef,
+      getToggleButtonProps,
     } = useSelectContext()
 
     const { getDropdownProps } = useMultiSelectContext()
@@ -83,21 +84,25 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
         <Box
           as="button"
           type="button"
-          alignSelf="flex-start"
-          aria-disabled={isDisabled}
-          sx={styles.chevron}
-          // Needed for screen readers to trigger toggle action
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          //@ts-ignore
-          onClick={(e) => {
-            handleToggleMenu()
-            e.stopPropagation()
+          _disabled={{
+            cursor: 'not-allowed',
           }}
+          alignSelf="flex-start"
+          sx={styles.chevron}
+          aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options`}
+          {...getToggleButtonProps({
+            disabled: isDisabled || isReadOnly,
+            // Allow navigation to this button with screen readers.
+            tabIndex: 0,
+            // onClick needs to be defined on the toggle button itself to allow
+            // screen readers to activate the click action, but need to stop
+            // bubbling up to the parent to avoid double-toggling
+            onClick: (e) => e.stopPropagation(),
+          })}
         >
           <Icon
             as={isOpen ? BxsChevronUp : BxsChevronDown}
-            aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options icon`}
-            aria-disabled={isDisabled}
+            aria-disabled={isDisabled || isReadOnly}
           />
         </Box>
       </Flex>

--- a/react/src/MultiSelect/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/react/src/MultiSelect/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -1,12 +1,5 @@
 import { forwardRef, PropsWithChildren, useCallback } from 'react'
-import {
-  Box,
-  chakra,
-  Flex,
-  Icon,
-  useMergeRefs,
-  VisuallyHidden,
-} from '@chakra-ui/react'
+import { Box, chakra, Flex, Icon, useMergeRefs } from '@chakra-ui/react'
 
 import { BxsChevronDown, BxsChevronUp } from '~/icons'
 import { useSelectContext } from '~/SingleSelect'
@@ -23,7 +16,6 @@ const MultiItemsContainer = ({ children }: PropsWithChildren) => {
 export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
   (_props, ref): JSX.Element => {
     const {
-      getComboboxProps,
       getInputProps,
       styles,
       isDisabled,
@@ -35,20 +27,19 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
       toggleMenu,
       isInvalid,
       inputRef,
-      inputAria,
     } = useSelectContext()
 
     const { getDropdownProps } = useMultiSelectContext()
 
     const mergedRefs = useMergeRefs(inputRef, ref)
 
-    const handleWrapperClick = useCallback(() => {
+    const handleToggleMenu = useCallback(() => {
       if (isDisabled || isReadOnly) return
-      setIsFocused(true)
-      toggleMenu()
       if (!isOpen) {
         inputRef?.current?.focus()
       }
+      toggleMenu()
+      setIsFocused(true)
     }, [inputRef, isDisabled, isOpen, isReadOnly, setIsFocused, toggleMenu])
 
     /**
@@ -69,33 +60,40 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
         aria-invalid={isInvalid}
         aria-readonly={isReadOnly}
         __css={styles.fieldwrapper}
-        {...getComboboxProps({
-          disabled: isDisabled,
-          readOnly: isReadOnly,
-          required: isRequired,
-          'aria-expanded': !!isOpen,
-          onClick: handleWrapperClick,
-        })}
+        onClick={handleToggleMenu}
       >
-        <VisuallyHidden id={inputAria.id}>{inputAria.label}</VisuallyHidden>
         <MultiItemsContainer>
           <SelectedItems />
           <chakra.input
             placeholder={placeholder}
             __css={styles.field}
-            {...getInputProps(
-              getDropdownProps({
+            {...getInputProps({
+              ...getDropdownProps({
                 ref: mergedRefs,
                 onFocus: () => setIsFocused(true),
                 onKeyDown: handleInputTabKeydown,
                 readOnly: isReadOnly,
                 disabled: isDisabled,
-                'aria-describedby': inputAria.id,
               }),
-            )}
+              required: isRequired,
+              'aria-expanded': !!isOpen,
+            })}
           />
         </MultiItemsContainer>
-        <Box aria-disabled={isDisabled} sx={styles.chevron}>
+        <Box
+          as="button"
+          type="button"
+          alignSelf="flex-start"
+          aria-disabled={isDisabled}
+          sx={styles.chevron}
+          // Needed for screen readers to trigger toggle action
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          //@ts-ignore
+          onClick={(e) => {
+            handleToggleMenu()
+            e.stopPropagation()
+          }}
+        >
           <Icon
             as={isOpen ? BxsChevronUp : BxsChevronDown}
             aria-label={`${isOpen ? 'Close' : 'Open'} dropdown options icon`}

--- a/react/src/MultiSelect/components/MultiSelectCombobox/SelectedItems.tsx
+++ b/react/src/MultiSelect/components/MultiSelectCombobox/SelectedItems.tsx
@@ -21,7 +21,13 @@ const ShowMoreItemBlock = ({ amountToShow }: { amountToShow: number }) => {
   )
 
   return (
-    <Button onClick={handleClick} variant="link" size="sm" tabIndex={-1}>
+    <Button
+      onClick={handleClick}
+      variant="link"
+      size="sm"
+      tabIndex={-1}
+      alignSelf="center"
+    >
       +{amountToShow} more
     </Button>
   )

--- a/react/src/SingleSelect/SelectContext.tsx
+++ b/react/src/SingleSelect/SelectContext.tsx
@@ -26,11 +26,6 @@ export interface SharedSelectContextReturnProps<
   name: string
   /** Item data used to render items in dropdown */
   items: Item[]
-  /** aria-describedby to be attached to the combobox input, if any. */
-  inputAria?: {
-    id: string
-    label: string
-  }
   size?: 'xs' | 'sm' | 'md'
 }
 
@@ -47,6 +42,11 @@ interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
   isFocused: boolean
   setIsFocused: (isFocused: boolean) => void
   inputRef?: MutableRefObject<HTMLInputElement | null>
+  /** aria-describedby to be attached to the combobox input, if any. */
+  inputAria?: {
+    id: string
+    label: string
+  }
   resetInputValue: () => void
   /** Ref for list virtualization */
   virtualListRef: RefObject<VirtuosoHandle>

--- a/react/src/SingleSelect/SingleSelectProvider.tsx
+++ b/react/src/SingleSelect/SingleSelectProvider.tsx
@@ -10,11 +10,7 @@ import { useCombobox, UseComboboxProps } from 'downshift'
 
 import { useItems } from './hooks/useItems'
 import { defaultFilter } from './utils/defaultFilter'
-import {
-  isItemDisabled,
-  itemToLabelString,
-  itemToValue,
-} from './utils/itemUtils'
+import { isItemDisabled, itemToValue } from './utils/itemUtils'
 import { VIRTUAL_LIST_ITEM_HEIGHT, VIRTUAL_LIST_MAX_HEIGHT } from './constants'
 import { SelectContext, SharedSelectContextReturnProps } from './SelectContext'
 import { ComboboxItem } from './types'
@@ -59,7 +55,7 @@ export const SingleSelectProvider = ({
   isDisabled: isDisabledProp,
   isRequired: isRequiredProp,
   children,
-  inputAria: inputAriaProp,
+  inputAria,
   colorScheme,
   size = 'md',
   comboboxProps = {},
@@ -109,7 +105,6 @@ export const SingleSelectProvider = ({
     closeMenu,
     isOpen,
     getLabelProps,
-    getComboboxProps,
     getMenuProps,
     getInputProps,
     getItemProps,
@@ -191,6 +186,11 @@ export const SingleSelectProvider = ({
             isOpen: false,
           }
         }
+        case useCombobox.stateChangeTypes.InputFocus:
+          return {
+            ...changes,
+            isOpen: false, // keep the menu closed when input gets focused.
+          }
         default:
           return changes
       }
@@ -218,18 +218,6 @@ export const SingleSelectProvider = ({
     colorScheme,
   })
 
-  const inputAria = useMemo(() => {
-    if (inputAriaProp) return inputAriaProp
-    let label = 'No option selected'
-    if (selectedItem) {
-      label = `Option ${itemToLabelString(selectedItem)}, selected`
-    }
-    return {
-      id: `${name}-current-selection`,
-      label,
-    }
-  }, [inputAriaProp, name, selectedItem])
-
   const virtualListHeight = useMemo(() => {
     const totalHeight = filteredItems.length * VIRTUAL_LIST_ITEM_HEIGHT[size]
     // If the total height is less than the max height, just return the total height.
@@ -246,7 +234,6 @@ export const SingleSelectProvider = ({
         isItemSelected,
         toggleMenu,
         closeMenu,
-        getComboboxProps,
         getInputProps,
         getItemProps,
         getLabelProps,

--- a/react/src/SingleSelect/SingleSelectProvider.tsx
+++ b/react/src/SingleSelect/SingleSelectProvider.tsx
@@ -151,7 +151,7 @@ export const SingleSelectProvider = ({
           return
       }
     },
-    stateReducer: (_state, { changes, type }) => {
+    stateReducer: (state, { changes, type }) => {
       switch (type) {
         // Handle controlled `value` prop changes.
         case useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem:
@@ -159,8 +159,8 @@ export const SingleSelectProvider = ({
           // This suggests that there is some initial input state that we want to keep.
           // This can only happen on first mount, since inputValue will be empty string
           // on future actions.
-          if (_state.inputValue && !changes.selectedItem) {
-            return { ...changes, inputValue: _state.inputValue }
+          if (state.inputValue && !changes.selectedItem) {
+            return { ...changes, inputValue: state.inputValue }
           }
           return {
             ...changes,
@@ -171,7 +171,7 @@ export const SingleSelectProvider = ({
           if (isClearable) return changes
           return {
             ...changes,
-            selectedItem: _state.selectedItem,
+            selectedItem: state.selectedItem,
           }
         }
         case useCombobox.stateChangeTypes.FunctionSelectItem:
@@ -190,6 +190,11 @@ export const SingleSelectProvider = ({
           return {
             ...changes,
             isOpen: false, // keep the menu closed when input gets focused.
+          }
+        case useCombobox.stateChangeTypes.ToggleButtonClick:
+          return {
+            ...changes,
+            isOpen: !state.isOpen,
           }
         default:
           return changes

--- a/react/src/SingleSelect/components/SelectCombobox/ComboboxClearButton.tsx
+++ b/react/src/SingleSelect/components/SelectCombobox/ComboboxClearButton.tsx
@@ -22,8 +22,9 @@ export const ComboboxClearButton = (): JSX.Element | null => {
 
   const [announceClearedInput, setAnnounceClearedInput] = useState(false)
   const handleClearSelection = useCallback(() => {
-    selectItem(null)
+    // Need to focus before selecting null. I have no idea why, but it works
     inputRef?.current?.focus()
+    selectItem(null)
     setAnnounceClearedInput(true)
   }, [inputRef, selectItem])
 
@@ -36,23 +37,26 @@ export const ComboboxClearButton = (): JSX.Element | null => {
   if (!isClearable) return null
 
   return (
-    <IconButton
-      // Prevent form submission from triggering this button.
-      type="button"
-      size={size}
-      aria-invalid={isInvalid}
-      isDisabled={isDisabled || isReadOnly}
-      aria-label={clearButtonLabel}
-      onClick={handleClearSelection}
-      variant="inputAttached"
-      icon={<BxX />}
-      isActive={!!inputValue || !!selectedItem}
-    >
+    <>
+      <IconButton
+        // Prevent form submission from triggering this button.
+        type="button"
+        size={size}
+        aria-invalid={isInvalid}
+        isDisabled={isDisabled || isReadOnly}
+        aria-label={clearButtonLabel}
+        onClick={handleClearSelection}
+        // Unmount the visually hidden announcement when navigated to this button
+        onFocus={() => setAnnounceClearedInput(false)}
+        variant="inputAttached"
+        icon={<BxX />}
+        isActive={!!inputValue || !!selectedItem}
+      />
       {announceClearedInput && (
         <VisuallyHidden aria-live="assertive">
           Selection has been cleared
         </VisuallyHidden>
       )}
-    </IconButton>
+    </>
   )
 }

--- a/react/src/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/react/src/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -6,7 +6,6 @@ import {
   Stack,
   Text,
   useMergeRefs,
-  VisuallyHidden,
 } from '@chakra-ui/react'
 
 import { Input } from '~/Input'
@@ -20,7 +19,6 @@ import { ToggleChevron } from './ToggleChevron'
 export const SelectCombobox = forwardRef<HTMLInputElement>(
   (_props, ref): JSX.Element => {
     const {
-      getComboboxProps,
       toggleMenu,
       selectedItem,
       getInputProps,
@@ -32,10 +30,8 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       inputValue,
       isRequired,
       placeholder,
-      setIsFocused,
       isOpen,
       resetInputValue,
-      inputAria,
       inputRef,
       isClearable,
       size,
@@ -58,7 +54,6 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
 
     return (
       <Flex>
-        <VisuallyHidden id={inputAria.id}>{inputAria.label}</VisuallyHidden>
         <InputGroup
           size={size}
           pos="relative"
@@ -68,13 +63,6 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             zIndex: 1,
           }}
           gridTemplateColumns="1fr"
-          {...getComboboxProps({
-            disabled: isDisabled,
-            readOnly: isReadOnly,
-            required: isRequired,
-            'aria-expanded': !!isOpen,
-            onFocus: () => setIsFocused(true),
-          })}
         >
           <Stack
             visibility={inputValue ? 'hidden' : 'initial'}
@@ -82,6 +70,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             spacing="1rem"
             aria-disabled={isDisabled}
             sx={styles.selected}
+            aria-hidden
           >
             {selectedItemMeta.icon ? (
               <Icon
@@ -102,7 +91,10 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
               onClick: handleToggleMenu,
               onBlur: () => !isOpen && resetInputValue(),
               ref: mergedInputRef,
-              'aria-describedby': inputAria.id,
+              disabled: isDisabled,
+              readOnly: isReadOnly,
+              required: isRequired,
+              'aria-expanded': !!isOpen,
             })}
           />
           <ToggleChevron />

--- a/react/src/SingleSelect/components/SelectCombobox/ToggleChevron.tsx
+++ b/react/src/SingleSelect/components/SelectCombobox/ToggleChevron.tsx
@@ -26,7 +26,6 @@ export const ToggleChevron = (): JSX.Element => {
       <Icon
         sx={styles.icon}
         as={isOpen ? BxsChevronUp : BxsChevronDown}
-        aria-hidden
         aria-disabled={isDisabled || isReadOnly}
       />
     </InputRightElement>


### PR DESCRIPTION
Supersedes #215

## Problem

The single select component is not fully accessible according to the [W3C WAI standard for comboboxes](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-both/). Some bugs in the old implementation included: 

- Input aria defined outside of the input element itself, making it hard to find where the currently-selected option is said.
- Overlapping stack and input within the combobox itself, which confuses screen readers by adding an additional `->` step
- Navigating to the combobox instantly toggling the menu, thus causing focus to jump around different components at unexpected times
- Clear selection not announcing input clearing correctly.

This PR fixes these issues. 

At the same time, I also took the chance to upgrade downshift, which means multiselect also had to be updated. Thus I took the chance to also fix some issues with the multiselect component.

- Similar issue with input aria as single select
- Toggle menu button not working as intended since no onClick is defined on the component
- `+x more` not center-aligned

## Solution

Upgrade downshift to 7.2.0. There are two breaking changes:
- `getComboboxProps` has been removed from the return type of `useCombobox` as listed [here](https://github.com/downshift-js/downshift/blob/master/src/hooks/MIGRATION_V7.md#usecombobox:~:text=getComboboxProps%20has%20been%20removed.), as a result of the wrapper element not receiving the combobox role attributes. Thus, the props given to `getComboboxProps` are passed to `getInputProps` instead.
- the menu automatically opens when the combobox receives focus as listed [here](https://github.com/downshift-js/downshift/blob/master/src/hooks/MIGRATION_V7.md#usecombobox:~:text=You%20don%27t%20need%20to%20change%20your%20reducer%20if%20you%20want%20to%20keep%20the%201.2%20functionality%20provided%20by%20default.%20However%2C%20if%20you%20want%20to%20keep%20the%20menu%20closed%20when%20the%20input%20gets%20focus%2C%20you%20can%20do%3A). However this was explicitly mentioned should not be the case during our a11y testing for FormSG. The workaround provided in the link above is used to get around this.

At the same time, in some places `aria-hidden` were added and some components moved around in order to fix the other bugs.

Additionally, moved menu toggling function to state reducer level since `getToggleButtonProps` are provided to the toggle buttons in both single and multi select.