### PR TITLE
fix(MultiSelect): set input to readonly if isSearchable is false

### DIFF
--- a/react/src/MultiSelect/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/react/src/MultiSelect/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -26,6 +26,7 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
       isOpen,
       toggleMenu,
       isInvalid,
+      isSearchable,
       inputRef,
       getToggleButtonProps,
     } = useSelectContext()
@@ -73,7 +74,7 @@ export const MultiSelectCombobox = forwardRef<HTMLInputElement>(
                 ref: mergedRefs,
                 onFocus: () => setIsFocused(true),
                 onKeyDown: handleInputTabKeydown,
-                readOnly: isReadOnly,
+                readOnly: isReadOnly || !isSearchable,
                 disabled: isDisabled,
               }),
               required: isRequired,


### PR DESCRIPTION
This PR fixes a bug where the `isSearchable` prop does nothing on `MultiSelect` components.