### PR TITLE
fix: use `-subtle` colors instead of non-existant `-light` prefix

### DIFF
--- a/react/src/theme/components/Avatar.ts
+++ b/react/src/theme/components/Avatar.ts
@@ -16,7 +16,7 @@ const getSubtleColorProps = ({ colorScheme: c }: StyleFunctionProps) => {
     case 'sub':
       return {
         color: `interaction.${c}.default`,
-        bg: `interaction.${c}-light.default`,
+        bg: `interaction.${c}-subtle.default`,
       }
     default:
       return {

--- a/react/src/theme/components/AvatarMenu.ts
+++ b/react/src/theme/components/AvatarMenu.ts
@@ -16,8 +16,8 @@ const getAvatarSubtleColorProps = ({ colorScheme: c }: StyleFunctionProps) => {
     case 'warning':
     case 'sub':
       return {
-        hoverBg: `interaction.${c}-light.hover`,
-        activeBg: `interaction.${c}-light.active`,
+        hoverBg: `interaction.${c}-subtle.hover`,
+        activeBg: `interaction.${c}-subtle.active`,
       }
     default:
       return {

--- a/react/src/theme/components/Tag.ts
+++ b/react/src/theme/components/Tag.ts
@@ -131,10 +131,10 @@ const getSubtleColors = defineStyle(({ colorScheme: c }) => {
     case 'critical':
       return {
         _hover: {
-          background: `interaction.${c}-light.hover`,
+          background: `interaction.${c}-subtle.hover`,
         },
         _active: {
-          background: `interaction.${c}-light.active`,
+          background: `interaction.${c}-subtle.active`,
         },
       }
   }


### PR DESCRIPTION
token names were changed but components theme declaration was missed
