### PR TITLE
fix: remove timezone from datepicker

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -14,7 +14,6 @@
         "@fontsource/ibm-plex-mono": "^4.5.13",
         "country-flag-icons": "^1.4.19",
         "date-fns": "^2.28.0",
-        "date-fns-tz": "^2.0.0",
         "dayzed": "^3.2.3",
         "downshift": "^7.2.0",
         "fuzzysort": "^2.0.1",
@@ -9058,14 +9057,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
-      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
-      "peerDependencies": {
-        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/dayzed": {
@@ -24587,12 +24578,6 @@
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
-    },
-    "date-fns-tz": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
-      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
-      "requires": {}
     },
     "dayzed": {
       "version": "3.2.3",

--- a/react/package.json
+++ b/react/package.json
@@ -37,7 +37,6 @@
     "@fontsource/ibm-plex-mono": "^4.5.13",
     "country-flag-icons": "^1.4.19",
     "date-fns": "^2.28.0",
-    "date-fns-tz": "^2.0.0",
     "dayzed": "^3.2.3",
     "downshift": "^7.2.0",
     "fuzzysort": "^2.0.1",

--- a/react/src/DatePicker/DatePickerContext.tsx
+++ b/react/src/DatePicker/DatePickerContext.tsx
@@ -21,7 +21,6 @@ import {
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 import { format, isValid, parse } from 'date-fns'
-import { zonedTimeToUtc } from 'date-fns-tz'
 
 import { useIsMobile } from '~/hooks'
 
@@ -84,7 +83,6 @@ const useProvideDatePicker = ({
   isReadOnly: isReadOnlyProp,
   isRequired: isRequiredProp,
   isInvalid: isInvalidProp,
-  timeZone = 'UTC',
   locale,
   isDateUnavailable,
   allowManualInput = true,
@@ -121,9 +119,9 @@ const useProvideDatePicker = ({
   const formatInputValue = useCallback(
     (date: Date | null) => {
       if (!date || !isValid(date)) return ''
-      return format(zonedTimeToUtc(date, timeZone), displayFormat, { locale })
+      return format(date, displayFormat, { locale })
     },
-    [displayFormat, locale, timeZone],
+    [displayFormat, locale],
   )
 
   // What is rendered as a string in the input according to given display format.
@@ -146,7 +144,7 @@ const useProvideDatePicker = ({
       const date = parse(
         internalInputValue,
         dateFormat,
-        zonedTimeToUtc(new Date(), timeZone),
+        new Date(),
       )
       // Clear if input is invalid on blur if invalid dates are not allowed.
       if (!allowInvalidDates && !isValid(date)) {
@@ -162,7 +160,6 @@ const useProvideDatePicker = ({
       onBlur,
       setInternalInputValue,
       setInternalValue,
-      timeZone,
     ],
   )
 
@@ -180,12 +177,11 @@ const useProvideDatePicker = ({
 
   const handleDateChange = useCallback(
     (date: Date | null) => {
-      const zonedDate = date ? zonedTimeToUtc(date, timeZone) : null
-      if (allowInvalidDates || isValid(zonedDate) || !zonedDate) {
-        setInternalValue(zonedDate)
+      if (allowInvalidDates || isValid(date) || !date) {
+        setInternalValue(date)
       }
-      if (zonedDate) {
-        setInternalInputValue(format(zonedDate, displayFormat, { locale }))
+      if (date) {
+        setInternalInputValue(format(date, displayFormat, { locale }))
       } else {
         setInternalInputValue('')
       }
@@ -199,7 +195,6 @@ const useProvideDatePicker = ({
       locale,
       setInternalInputValue,
       setInternalValue,
-      timeZone,
     ],
   )
 
@@ -208,14 +203,14 @@ const useProvideDatePicker = ({
       const date = parse(
         event.target.value,
         dateFormat,
-        zonedTimeToUtc(new Date(), timeZone),
+        new Date(),
       )
       setInternalInputValue(event.target.value)
       if (isValid(date)) {
         setInternalValue(date)
       }
     },
-    [dateFormat, setInternalInputValue, setInternalValue, timeZone],
+    [dateFormat, setInternalInputValue, setInternalValue],
   )
 
   const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(

--- a/react/src/DateRangePicker/DateRangePickerContext.tsx
+++ b/react/src/DateRangePicker/DateRangePickerContext.tsx
@@ -22,7 +22,6 @@ import {
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 import { format, isValid, parse } from 'date-fns'
-import { zonedTimeToUtc } from 'date-fns-tz'
 
 import { DateRangeValue } from '~/Calendar'
 import { useIsMobile } from '~/hooks/useIsMobile'
@@ -130,13 +129,13 @@ const useProvideDateRangePicker = ({
   // What is rendered as a string in the start date range input according to given display format.
   const [startInputDisplay, setStartInputDisplay] = useState(
     startDate && isValid(startDate)
-      ? format(zonedTimeToUtc(startDate, timeZone), displayFormat, { locale })
+      ? format(startDate, displayFormat, { locale })
       : '',
   )
   // What is rendered as a string in the end date range input according to given display format.
   const [endInputDisplay, setEndInputDisplay] = useState(
     endDate && isValid(endDate)
-      ? format(zonedTimeToUtc(endDate, timeZone), displayFormat, { locale })
+      ? format(endDate, displayFormat, { locale })
       : '',
   )
 
@@ -152,14 +151,10 @@ const useProvideDateRangePicker = ({
       ) as DateRangeValue
 
       const [nextStart, nextEnd] = sortedRange
-      const zonedStartDate = nextStart
-        ? zonedTimeToUtc(nextStart, timeZone)
-        : null
-      const zonedEndDate = nextEnd ? zonedTimeToUtc(nextEnd, timeZone) : null
-      if (zonedStartDate) {
-        if (isValid(zonedStartDate)) {
+      if (nextStart) {
+        if (isValid(nextStart)) {
           setStartInputDisplay(
-            format(zonedStartDate, displayFormat, { locale }),
+            format(nextStart, displayFormat, { locale }),
           )
         } else if (!allowInvalidDates) {
           setStartInputDisplay('')
@@ -167,9 +162,9 @@ const useProvideDateRangePicker = ({
       } else {
         setStartInputDisplay('')
       }
-      if (zonedEndDate) {
-        if (isValid(zonedEndDate)) {
-          setEndInputDisplay(format(zonedEndDate, displayFormat, { locale }))
+      if (nextEnd) {
+        if (isValid(nextEnd)) {
+          setEndInputDisplay(format(nextEnd, displayFormat, { locale }))
         } else if (!allowInvalidDates) {
           setEndInputDisplay('')
         }
@@ -278,7 +273,7 @@ const useProvideDateRangePicker = ({
   const handleCalendarDateChange = useCallback(
     (date: DateRangeValue) => {
       const zonedDateRange = date.map((d) =>
-        d ? zonedTimeToUtc(d, timeZone) : null,
+        d,
       ) as DateRangeValue
       const [nextStartDate, nextEndDate] = zonedDateRange
       setInternalValue(zonedDateRange)

--- a/react/src/DateRangePicker/DateRangePickerContext.tsx
+++ b/react/src/DateRangePicker/DateRangePickerContext.tsx
@@ -272,11 +272,8 @@ const useProvideDateRangePicker = ({
 
   const handleCalendarDateChange = useCallback(
     (date: DateRangeValue) => {
-      const zonedDateRange = date.map((d) =>
-        d,
-      ) as DateRangeValue
-      const [nextStartDate, nextEndDate] = zonedDateRange
-      setInternalValue(zonedDateRange)
+      const [nextStartDate, nextEndDate] = date
+      setInternalValue(date)
       setStartInputDisplay(
         nextStartDate ? format(nextStartDate, displayFormat, { locale }) : '',
       )


### PR DESCRIPTION
## Problem

Date picker was using the midnight of the date picked and taking into account the timezone where the user is filling in the form. However, it does not make sense to do so as users will be picking particular dates rather than timings, and the understanding of the different timezones should be established as part of the question.

Same fix added to [FormSG](https://github.com/opengovsg/FormSG) on https://github.com/opengovsg/FormSG/pull/6025

## Solution

Remove the portions of the code to account for timezone differences. This allows the text field of the calendar field to reflect the date selected on the date picker.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible. This the pure frontend change.

**Bug Fixes**:

- Remove timezone conversions previously included in datepicker