### PR TITLE
feat: allow ChakraProps to be used in Sidebar components

### DIFF
--- a/react/src/Sidebar/SidebarHeader.tsx
+++ b/react/src/Sidebar/SidebarHeader.tsx
@@ -5,7 +5,7 @@ import type { BaseSidebarItemProps } from './types'
 
 export type SidebarHeaderProps = BaseSidebarItemProps
 
-export const SidebarHeader = forwardRef<SidebarHeaderProps, 'li'>(
+export const SidebarHeader = forwardRef<SidebarHeaderProps, 'div'>(
   ({ children, icon, iconProps, ...props }, ref): JSX.Element => {
     const styles = useSidebarStyles()
 

--- a/react/src/Sidebar/types.ts
+++ b/react/src/Sidebar/types.ts
@@ -1,7 +1,8 @@
 import type { PropsWithChildren } from 'react'
-import { IconProps } from '@chakra-ui/react'
+import { ChakraProps, IconProps } from '@chakra-ui/react'
 
 export type BaseSidebarItemProps = PropsWithChildren<{
   icon?: React.ElementType
   iconProps?: IconProps
-}>
+}> &
+  ChakraProps


### PR DESCRIPTION
Allow chakra props (e.g. `px`, `position`, etc) to be passed into Sidebar's underlying components.

Currently already does that since props are spread into the components, but the typings do not show it. This PR adds the correct typings into the component.