### PR TITLE
fix: respect size defaultProps in MultiSelect, SingleSelect component

### DIFF
--- a/react/src/MultiSelect/MultiSelectProvider.tsx
+++ b/react/src/MultiSelect/MultiSelectProvider.tsx
@@ -5,6 +5,7 @@ import {
   ThemingProps,
   useFormControlProps,
   useMultiStyleConfig,
+  useTheme,
 } from '@chakra-ui/react'
 import {
   useCombobox,
@@ -88,9 +89,20 @@ export const MultiSelectProvider = ({
   downshiftMultiSelectProps = {},
   inputAria,
   children,
-  size = 'md',
+  size: _size,
   colorScheme,
 }: MultiSelectProviderProps): JSX.Element => {
+  const theme = useTheme()
+  // Required in case size is set in theme, we should respect the one set in theme.
+  const size = useMemo(
+    () =>
+      (_size ?? theme?.components?.MultiSelect?.defaultProps?.size ?? 'md') as
+        | 'xs'
+        | 'sm'
+        | 'md',
+    [_size, theme?.components?.MultiSelect?.defaultProps?.size],
+  )
+
   const { items, getItemByValue } = useItems({ rawItems })
   const [isFocused, setIsFocused] = useState(false)
 

--- a/react/src/SingleSelect/SingleSelectProvider.tsx
+++ b/react/src/SingleSelect/SingleSelectProvider.tsx
@@ -5,6 +5,7 @@ import {
   ThemingProps,
   useFormControlProps,
   useMultiStyleConfig,
+  useTheme,
 } from '@chakra-ui/react'
 import { useCombobox, UseComboboxProps } from 'downshift'
 
@@ -57,9 +58,20 @@ export const SingleSelectProvider = ({
   children,
   inputAria,
   colorScheme,
-  size = 'md',
+  size: _size,
   comboboxProps = {},
 }: SingleSelectProviderProps): JSX.Element => {
+  const theme = useTheme()
+  // Required in case size is set in theme, we should respect the one set in theme.
+  const size = useMemo(
+    () =>
+      (_size ?? theme?.components?.SingleSelect?.defaultProps?.size ?? 'md') as
+        | 'xs'
+        | 'sm'
+        | 'md',
+    [_size, theme?.components?.SingleSelect?.defaultProps?.size],
+  )
+
   const { items, getItemByValue } = useItems({ rawItems })
   const [isFocused, setIsFocused] = useState(false)
 


### PR DESCRIPTION
Previously, the size was set to default to 'md' in the SelectProviders, but this meant setting the size as a default prop in the theme declaration would always be overridden by the default size assignment in the component itself.

This PR fixes that by setting the respective `size` priority to be:
size prop > theme prop > 'md' assignment if does not exist in theme