### PR TITLE
feat: add indeterminate and inverse scheme

### DIFF
--- a/react/src/Checkbox/Checkbox.stories.tsx
+++ b/react/src/Checkbox/Checkbox.stories.tsx
@@ -26,6 +26,20 @@ Default.args = {
   name: 'Default',
 }
 
+export const Indeterminate = Template.bind({})
+Indeterminate.args = {
+  name: 'Indeterminate',
+  isIndeterminate: true,
+}
+
+export const Inverse = Template.bind({})
+Inverse.args = {
+  name: 'Inverse',
+  colorScheme: 'inverse',
+  isIndeterminate: false,
+  isChecked: false,
+}
+
 export const Mobile = Template.bind({})
 Mobile.args = {
   name: 'Mobile',

--- a/react/src/Checkbox/Checkbox.tsx
+++ b/react/src/Checkbox/Checkbox.tsx
@@ -11,7 +11,8 @@ import {
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
-import { BxCheckAnimated } from '~/icons'
+import { BxCheckAnimated, BxsCircle } from '~/icons'
+import { BxIndeterminate } from '~/icons/BxIndeterminate'
 import { Input, InputProps } from '~/Input'
 
 import { CheckboxOthersContext, useCheckboxOthers } from './useCheckboxOthers'
@@ -25,14 +26,15 @@ type CheckboxWithOthers = ComponentWithAs<'input', CheckboxProps> & {
 }
 
 export const Checkbox = forwardRef<CheckboxProps, 'input'>(
-  ({ children, colorScheme, ...props }, ref) => {
+  ({ children, colorScheme, isIndeterminate, ...props }, ref) => {
     // Passing all props for cleanliness but the size prop is the most relevant
     const { icon: iconStyles } = useMultiStyleConfig('Checkbox', props)
+
     return (
       <ChakraCheckbox
         icon={
           <Icon
-            as={BxCheckAnimated}
+            as={isIndeterminate ? BxIndeterminate : BxCheckAnimated}
             __css={iconStyles}
             // This prop needs to be passed explicitly for animations
             isChecked={props.isChecked}

--- a/react/src/icons/BxIndeterminate.tsx
+++ b/react/src/icons/BxIndeterminate.tsx
@@ -1,0 +1,15 @@
+// source from chakra indetermiante icon here https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/checkbox/src/checkbox-icon.tsx
+export const BxIndeterminate = (
+  props: React.SVGProps<SVGSVGElement>,
+): JSX.Element => {
+  return (
+    <svg
+      width="1.2em"
+      viewBox="0 0 24 24"
+      style={{ stroke: 'currentColor', strokeWidth: 4 }}
+      {...props}
+    >
+      <line x1="21" x2="3" y1="12" y2="12" />
+    </svg>
+  )
+}

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -100,7 +100,7 @@ const baseStyle = definePartsStyle((props) => {
     },
     // Check mark icon
     icon: {
-      // Chakra changes the icon colour if disabled, but we want it to always be white
+      // Chakra changes the icon colour if disabled, but we want it to always be either the `main` or `inverse` iconColours
       color: iconColor ?? 'white',
       // Remove default Chakra animations so we can replace with our own. This is because
       // we ran into issues where we could not increase the size of the tick icon without

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -28,6 +28,14 @@ const getColorProps = ({ colorScheme: c }: StyleFunctionProps) => {
         hoverBg: 'interaction.muted.main.hover',
         borderColor: 'interaction.main.default',
       }
+    case 'inverse':
+      return {
+        bg: 'white',
+        checkedBg: 'white',
+        iconColor: 'interaction.main.default',
+        hoverBg: 'interaction.muted.main.hover',
+        borderColor: 'interaction.main.default',
+      }
     default: {
       return {
         bg: 'white',
@@ -39,7 +47,8 @@ const getColorProps = ({ colorScheme: c }: StyleFunctionProps) => {
 }
 
 const baseStyle = definePartsStyle((props) => {
-  const { bg, hoverBg, borderColor, checkedBg } = getColorProps(props)
+  const { bg, hoverBg, borderColor, checkedBg, iconColor } =
+    getColorProps(props)
   return {
     // Control is the box containing the check icon
     control: {
@@ -92,7 +101,7 @@ const baseStyle = definePartsStyle((props) => {
     // Check mark icon
     icon: {
       // Chakra changes the icon colour if disabled, but we want it to always be white
-      color: 'white',
+      color: iconColor ?? 'white',
       // Remove default Chakra animations so we can replace with our own. This is because
       // we ran into issues where we could not increase the size of the tick icon without
       // the animation messing up.


### PR DESCRIPTION
## Problem

Add inverse colour scheme for `Checkbox` and indeterminate icon support

## Solution

- Extract iconColour prop from `getColour`, followed colour schemes from pearyl's design on Bright
- Create interderminate icon, which is cmd c + v from Chakra's indeterminate icon