### PR TITLE
fix: custom close button for banner

### DIFF
--- a/react/src/Banner/Banner.tsx
+++ b/react/src/Banner/Banner.tsx
@@ -62,7 +62,7 @@ export const Banner = ({
 
   const closeButtonRendered = useMemo(() => {
     if (!isDismissable) return null
-    if (closeButton !== undefined) closeButton
+    if (closeButton !== undefined) return closeButton
     return (
       <CloseButton children={<BxX />} onClick={onToggle} sx={styles.close} />
     )


### PR DESCRIPTION
## Problem

Closes #398 

## Solution

In the third line, the code was previously as follows. It does not return the custom close button, so the function continues and returns the default close button, regardless of whether the `closeButton` prop was passed in or not.

```js
const closeButtonRendered = useMemo(() => {
  if (!isDismissable) return null
  if (closeButton !== undefined) closeButton
  return (
    <CloseButton children={<BxX />} onClick={onToggle} sx={styles.close} />
  )
}, [closeButton, isDismissable, onToggle, styles.close])
```

The fix is to change the third line to

```if (closeButton !== undefined) return closeButton```

## Before & After Screenshots

Example (local edit in `Banner.stories.tsx`)

<img width="1285" alt="image" src="https://github.com/opengovsg/design-system/assets/20338724/6a74814f-65e9-4c91-acce-d3f5007619f6">