### PR TITLE
feat: add darkmode to checkbox, inverse colorScheme

### DIFF
--- a/react/.storybook/preview.tsx
+++ b/react/.storybook/preview.tsx
@@ -49,11 +49,18 @@ const withTheme = withThemeFromJSXProvider({
 })
 
 const withColorMode: Decorator = (storyFn, context) => {
-  const colorMode =
-    context.parameters.colorMode ||
-    get(context, 'globals.backgrounds.value') === backgrounds.dark.value
-      ? 'dark'
-      : 'light'
+  const bgFromContext = get(context, 'globals.backgrounds.value')
+  const bgFromDefault = get(context, 'parameters.backgrounds.default')
+  let colorMode: 'dark' | 'light' = 'light'
+  if (!bgFromContext && bgFromDefault) {
+    colorMode = context.parameters.backgrounds.default as 'dark' | 'light'
+  } else {
+    colorMode =
+      context.parameters.colorMode ||
+      get(context, 'globals.backgrounds.value') === backgrounds.dark.value
+        ? 'dark'
+        : 'light'
+  }
 
   return <ColorModeProvider value={colorMode}>{storyFn()}</ColorModeProvider>
 }

--- a/react/.storybook/preview.tsx
+++ b/react/.storybook/preview.tsx
@@ -38,7 +38,13 @@ export const parameters = {
     },
   },
   backgrounds: {
-    values: Object.values(backgrounds),
+    values: [
+      ...Object.values(backgrounds),
+      {
+        name: 'blue',
+        value: '#1361F0',
+      },
+    ],
   },
 }
 
@@ -53,7 +59,9 @@ const withColorMode: Decorator = (storyFn, context) => {
   const bgFromDefault = get(context, 'parameters.backgrounds.default')
   let colorMode: 'dark' | 'light' = 'light'
   if (!bgFromContext && bgFromDefault) {
-    colorMode = context.parameters.backgrounds.default as 'dark' | 'light'
+    if (['dark', 'light'].includes(context.parameters.backgrounds.default)) {
+      colorMode = context.parameters.backgrounds.default as 'dark' | 'light'
+    }
   } else {
     colorMode =
       context.parameters.colorMode ||

--- a/react/src/Checkbox/Checkbox.stories.tsx
+++ b/react/src/Checkbox/Checkbox.stories.tsx
@@ -1,12 +1,5 @@
 import { useMemo } from 'react'
-import {
-  Box,
-  CheckboxGroup,
-  DarkMode,
-  FormControl,
-  Stack,
-  VStack,
-} from '@chakra-ui/react'
+import { CheckboxGroup, FormControl, Stack, VStack } from '@chakra-ui/react'
 import { Meta, StoryFn } from '@storybook/react'
 
 import { FormLabel } from '~/FormControl/FormLabel'
@@ -71,6 +64,11 @@ const AllStates: StoryFn<CheckboxProps> = (args) => {
 
 export const CheckboxStates = AllStates.bind({})
 
+export const DarkmodeCheckboxStates: StoryFn = AllStates.bind({})
+DarkmodeCheckboxStates.parameters = {
+  backgrounds: { default: 'dark' },
+}
+
 export const CheckboxSizes = () => (
   <VStack>
     <Checkbox size="xs">xs</Checkbox>
@@ -83,7 +81,7 @@ export const CheckboxSizes = () => (
   </VStack>
 )
 
-export const CheckboxColors = () => (
+export const CheckboxColors: StoryFn = () => (
   <VStack>
     <Checkbox defaultChecked colorScheme="main">
       main
@@ -109,10 +107,11 @@ export const CheckboxColors = () => (
   </VStack>
 )
 
-export const DarkmodeCheckboxColors: StoryFn = () => <CheckboxColors />
+export const DarkmodeCheckboxColors = CheckboxColors.bind({})
 DarkmodeCheckboxColors.parameters = {
   backgrounds: { default: 'dark' },
 }
+
 export const Playground: StoryFn = ({ label, ...args }) => {
   const options = useMemo(() => ['Option 1', 'Option 2', 'Option 3'], [])
 

--- a/react/src/Checkbox/Checkbox.stories.tsx
+++ b/react/src/Checkbox/Checkbox.stories.tsx
@@ -86,6 +86,9 @@ export const CheckboxColors: StoryFn = () => (
     <Checkbox defaultChecked colorScheme="main">
       main
     </Checkbox>
+    <Checkbox defaultChecked colorScheme="inverse">
+      inverse
+    </Checkbox>
     <Checkbox defaultChecked colorScheme="red">
       red
     </Checkbox>

--- a/react/src/Checkbox/Checkbox.stories.tsx
+++ b/react/src/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,12 @@
 import { useMemo } from 'react'
-import { CheckboxGroup, FormControl, Stack, VStack } from '@chakra-ui/react'
+import {
+  Box,
+  CheckboxGroup,
+  DarkMode,
+  FormControl,
+  Stack,
+  VStack,
+} from '@chakra-ui/react'
 import { Meta, StoryFn } from '@storybook/react'
 
 import { FormLabel } from '~/FormControl/FormLabel'
@@ -102,6 +109,10 @@ export const CheckboxColors = () => (
   </VStack>
 )
 
+export const DarkmodeCheckboxColors: StoryFn = () => <CheckboxColors />
+DarkmodeCheckboxColors.parameters = {
+  backgrounds: { default: 'dark' },
+}
 export const Playground: StoryFn = ({ label, ...args }) => {
   const options = useMemo(() => ['Option 1', 'Option 2', 'Option 3'], [])
 

--- a/react/src/Checkbox/Checkbox.tsx
+++ b/react/src/Checkbox/Checkbox.tsx
@@ -30,6 +30,7 @@ export const Checkbox = forwardRef<CheckboxProps, 'input'>(
     const { icon: iconStyles } = useMultiStyleConfig('Checkbox', props)
     return (
       <ChakraCheckbox
+        data-group
         icon={
           <Icon
             as={BxCheckAnimated}

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -103,8 +103,10 @@ const baseStyle = definePartsStyle((props) => {
     },
     // Check mark icon
     icon: {
-      // Chakra changes the icon colour if disabled, but we want it to always be white
       color: iconColor,
+      _groupDisabled: {
+        color: 'white',
+      },
       // Remove default Chakra animations so we can replace with our own. This is because
       // we ran into issues where we could not increase the size of the tick icon without
       // the animation messing up.

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -31,6 +31,15 @@ const getColorProps = (props: StyleFunctionProps) => {
         hoverBg: 'interaction.muted.main.hover',
         borderColor: 'interaction.main.default',
       }
+    // Darkmode without setting dark mode, but only for main color scheme.
+    case 'inverse':
+      return {
+        bg: 'white',
+        checkedBg: 'white',
+        iconColor: 'interaction.main.default',
+        hoverBg: 'interaction.muted.main.hover',
+        borderColor: 'interaction.main.default',
+      }
     default: {
       return {
         bg: 'white',

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -39,6 +39,7 @@ const getColorProps = (props: StyleFunctionProps) => {
         iconColor: 'interaction.main.default',
         hoverBg: 'interaction.muted.main.hover',
         borderColor: 'interaction.main.default',
+        focusRingOutline: `2px solid var(--chakra-colors-utility-focus-inverse)`,
       }
     default: {
       return {
@@ -53,7 +54,7 @@ const getColorProps = (props: StyleFunctionProps) => {
 }
 
 const baseStyle = definePartsStyle((props) => {
-  const { bg, hoverBg, borderColor, iconColor, checkedBg } =
+  const { bg, hoverBg, borderColor, iconColor, checkedBg, focusRingOutline } =
     getColorProps(props)
   return {
     // Control is the box containing the check icon
@@ -92,6 +93,7 @@ const baseStyle = definePartsStyle((props) => {
       },
       _focusWithin: {
         ...layerStyles.focusRing.default._focusVisible,
+        ...(focusRingOutline ? { outline: focusRingOutline } : {}),
         outlineOffset: 0,
       },
     },

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -1,8 +1,9 @@
 import { checkboxAnatomy } from '@chakra-ui/anatomy'
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
-import { mode, StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { getColor, mode, StyleFunctionProps } from '@chakra-ui/theme-tools'
 
 import { layerStyles } from '../layerStyles'
+import { getContrastColor } from '../utils'
 
 import { Input } from './Input'
 
@@ -25,36 +26,49 @@ const getColorProps = (props: StyleFunctionProps) => {
   switch (c) {
     case 'main':
       return {
-        bg: 'white',
-        checkedBg: mode('interaction.main.default', 'white')(props),
-        iconColor: mode('white', 'interaction.main.default')(props),
-        hoverBg: 'interaction.muted.main.hover',
-        borderColor: 'interaction.main.default',
+        bg: mode('white', 'transparent')(props),
+        checkedBg: 'interaction.main.default',
+        iconColor: 'white',
+        hoverBg: mode(
+          'interaction.muted.main.hover',
+          'interaction.tinted.main.active',
+        )(props),
+        borderColor: mode('interaction.main.default', 'white')(props),
+        labelColor: mode('base.content.default', 'base.content.inverse')(props),
       }
-    // Darkmode without setting dark mode, but only for main color scheme.
+    // Inverse color scheme, used for darker backgrounds.
     case 'inverse':
       return {
-        bg: 'white',
+        bg: 'transparent',
         checkedBg: 'white',
-        iconColor: 'interaction.main.default',
-        hoverBg: 'interaction.muted.main.hover',
-        borderColor: 'interaction.main.default',
+        iconColor: 'base.content.strong',
+        hoverBg: 'interaction.tinted.inverse.hover',
+        borderColor: 'white',
+        labelColor: 'base.content.inverse',
       }
     default: {
       return {
-        bg: 'white',
-        iconColor: mode('white', `${c}.500`)(props),
-        checkedBg: mode(`${c}.500`, 'white')(props),
+        bg: mode('white', 'transparent')(props),
+        checkedBg: `${c}.500`,
+        iconColor: 'white',
         hoverBg: `${c}.100`,
         borderColor: `${c}.500`,
+        labelColor: mode('base.content.default', 'base.content.inverse')(props),
       }
     }
   }
 }
 
 const baseStyle = definePartsStyle((props) => {
-  const { bg, hoverBg, borderColor, iconColor, checkedBg } =
+  const { bg, hoverBg, borderColor, iconColor, checkedBg, labelColor } =
     getColorProps(props)
+
+  const hoverLabelColor = getContrastColor(
+    getColor(props.theme, labelColor),
+    getColor(props.theme, hoverBg),
+    'base.content.default',
+  )
+
   return {
     // Control is the box containing the check icon
     control: {
@@ -64,7 +78,7 @@ const baseStyle = definePartsStyle((props) => {
       borderColor,
       _checked: {
         bg: checkedBg,
-        borderColor,
+        borderColor: checkedBg,
       },
       // When the label is long and overflows to the next line, we want
       // the checkbox to be aligned with the first line rather than the center
@@ -74,7 +88,7 @@ const baseStyle = definePartsStyle((props) => {
       },
       _disabled: {
         borderColor: 'interaction.support.disabled-content',
-        bg: 'white',
+        bg,
         _checked: {
           borderColor: 'interaction.support.disabled-content',
           bg: 'interaction.support.disabled-content',
@@ -102,9 +116,9 @@ const baseStyle = definePartsStyle((props) => {
         // Chakra automatically sets opacity to 0.4, so override that
         opacity: 1,
       },
-      color: mode('base.content.strong', 'white')(props),
+      color: labelColor,
       _groupHover: {
-        color: 'base.content.strong',
+        color: hoverLabelColor,
         _disabled: {
           color: 'interaction.support.disabled-content',
         },

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -39,7 +39,6 @@ const getColorProps = (props: StyleFunctionProps) => {
         iconColor: 'interaction.main.default',
         hoverBg: 'interaction.muted.main.hover',
         borderColor: 'interaction.main.default',
-        focusRingOutline: `2px solid var(--chakra-colors-utility-focus-inverse)`,
       }
     default: {
       return {
@@ -54,7 +53,7 @@ const getColorProps = (props: StyleFunctionProps) => {
 }
 
 const baseStyle = definePartsStyle((props) => {
-  const { bg, hoverBg, borderColor, iconColor, checkedBg, focusRingOutline } =
+  const { bg, hoverBg, borderColor, iconColor, checkedBg } =
     getColorProps(props)
   return {
     // Control is the box containing the check icon
@@ -93,7 +92,6 @@ const baseStyle = definePartsStyle((props) => {
       },
       _focusWithin: {
         ...layerStyles.focusRing.default._focusVisible,
-        ...(focusRingOutline ? { outline: focusRingOutline } : {}),
         outlineOffset: 0,
       },
     },

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -1,6 +1,6 @@
 import { checkboxAnatomy } from '@chakra-ui/anatomy'
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
-import { StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { mode, StyleFunctionProps } from '@chakra-ui/theme-tools'
 
 import { layerStyles } from '../layerStyles'
 
@@ -19,18 +19,23 @@ const parts = checkboxAnatomy.extend(
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
-const getColorProps = ({ colorScheme: c }: StyleFunctionProps) => {
+const getColorProps = (props: StyleFunctionProps) => {
+  const { colorScheme: c } = props
+
   switch (c) {
     case 'main':
       return {
         bg: 'white',
-        checkedBg: 'interaction.main.default',
+        checkedBg: mode('interaction.main.default', 'white')(props),
+        iconColor: mode('white', 'interaction.main.default')(props),
         hoverBg: 'interaction.muted.main.hover',
         borderColor: 'interaction.main.default',
       }
     default: {
       return {
         bg: 'white',
+        iconColor: mode('white', `${c}.500`)(props),
+        checkedBg: mode(`${c}.500`, 'white')(props),
         hoverBg: `${c}.100`,
         borderColor: `${c}.500`,
       }
@@ -39,7 +44,8 @@ const getColorProps = ({ colorScheme: c }: StyleFunctionProps) => {
 }
 
 const baseStyle = definePartsStyle((props) => {
-  const { bg, hoverBg, borderColor, checkedBg } = getColorProps(props)
+  const { bg, hoverBg, borderColor, iconColor, checkedBg } =
+    getColorProps(props)
   return {
     // Control is the box containing the check icon
     control: {
@@ -87,12 +93,18 @@ const baseStyle = definePartsStyle((props) => {
         // Chakra automatically sets opacity to 0.4, so override that
         opacity: 1,
       },
-      color: 'base.content.strong',
+      color: mode('base.content.strong', 'white')(props),
+      _groupHover: {
+        color: 'base.content.strong',
+        _disabled: {
+          color: 'interaction.support.disabled-content',
+        },
+      },
     },
     // Check mark icon
     icon: {
       // Chakra changes the icon colour if disabled, but we want it to always be white
-      color: 'white',
+      color: iconColor,
       // Remove default Chakra animations so we can replace with our own. This is because
       // we ran into issues where we could not increase the size of the tick icon without
       // the animation messing up.

--- a/react/src/theme/utils/contrast.ts
+++ b/react/src/theme/utils/contrast.ts
@@ -64,12 +64,12 @@ const getLuminance = (rgbColour: RgbColour) => {
  * @param background the background colour
  * @returns true if the contrast ratio is greater than 4.5; false otherwise (or if one of the colours are invalid)
  */
-export const meetsWcagAaRatio = (
+export const isMeetsWcagAaRatio = (
   foreground: string,
   background: string,
-): boolean => {
+): boolean | null => {
   const contrast = getContrast(foreground, background)
-  if (!contrast) return false
+  if (contrast === null) return null
   return contrast >= MIN_WCAG_AA_CONTRAST_RATIO
 }
 
@@ -100,8 +100,7 @@ export const getContrastColor = (
   bg: string,
   fallback: string,
 ): string => {
-  if (meetsWcagAaRatio(fg, bg)) {
-    return fg
-  }
-  return fallback
+  const meetsWcagAaRatio = isMeetsWcagAaRatio(fg, bg)
+  if (meetsWcagAaRatio === null) return fg
+  return meetsWcagAaRatio ? fg : fallback
 }


### PR DESCRIPTION
> This PR is built on @austinwoon's initial work in https://github.com/opengovsg/design-system/pull/396


This PR adds a darkmode variant to Checkbox. To use it even in light mode, just wrap the component (or any parent) with ChakraUI's `DarkMode` component.

e.g.

```tsx
import { DarkMode } from '@chakra-ui/react'
import { Checkbox } from '@opengovsg/design-system-react'

const DarkmodeCheckbox = () => <DarkMode><Checkbox>Darkmode</Checkbox></Darkmode>
```

Also add `inverse` colorScheme to Checkbox, but the color will default to `main` colours