### PR TITLE
feat(calender/datepicker):  allow fixed height and mobile UX improvements

### DIFF
--- a/react/src/Calendar/Calendar.stories.tsx
+++ b/react/src/Calendar/Calendar.stories.tsx
@@ -44,6 +44,11 @@ HideOutsideDays.args = {
   showOutsideDays: false,
 }
 
+export const HideTodayButton = CalendarOnlyTemplate.bind({})
+HideTodayButton.args = {
+  showTodayButton: false,
+}
+
 export const CalendarWeekdayOnly = CalendarOnlyTemplate.bind({})
 CalendarWeekdayOnly.args = {
   isDateUnavailable: (d) => isWeekend(d),

--- a/react/src/Calendar/Calendar.stories.tsx
+++ b/react/src/Calendar/Calendar.stories.tsx
@@ -39,6 +39,11 @@ CalendarWithValue.args = {
   value: new Date('2001-01-01'),
 }
 
+export const HideOutsideDays = CalendarOnlyTemplate.bind({})
+HideOutsideDays.args = {
+  showOutsideDays: false,
+}
+
 export const CalendarWeekdayOnly = CalendarOnlyTemplate.bind({})
 CalendarWeekdayOnly.args = {
   isDateUnavailable: (d) => isWeekend(d),

--- a/react/src/Calendar/Calendar.tsx
+++ b/react/src/Calendar/Calendar.tsx
@@ -14,9 +14,12 @@ import {
   CalendarProvider,
   CalendarStylesProvider,
   CalendarTodayButton,
+  UseProvideCalendarProps,
 } from './CalendarBase'
 
-export interface CalendarProps extends CalendarBaseProps {
+export interface CalendarProps
+  extends CalendarBaseProps,
+    Pick<UseProvideCalendarProps, 'showOutsideDays'> {
   /**
    * The current selected date.
    * If provided, the input will be a controlled input, and `onChange` must be provided.

--- a/react/src/Calendar/Calendar.tsx
+++ b/react/src/Calendar/Calendar.tsx
@@ -40,7 +40,10 @@ export interface CalendarProps
 }
 
 export const Calendar = forwardRef<CalendarProps, 'input'>(
-  ({ value, onChange, defaultValue, ...props }, initialFocusRef) => {
+  (
+    { value, onChange, defaultValue, showTodayButton = true, ...props },
+    initialFocusRef,
+  ) => {
     const styles = useMultiStyleConfig('Calendar', props)
 
     const [internalValue, setInternalValue] = useControllableState({
@@ -59,7 +62,7 @@ export const Calendar = forwardRef<CalendarProps, 'input'>(
           <CalendarAria />
           <Stack spacing={0} divider={<StackDivider />} sx={styles.container}>
             <CalendarPanel ref={initialFocusRef} />
-            <CalendarTodayButton />
+            {showTodayButton && <CalendarTodayButton />}
           </Stack>
         </CalendarStylesProvider>
       </CalendarProvider>

--- a/react/src/Calendar/CalendarBase/CalendarContext.tsx
+++ b/react/src/Calendar/CalendarBase/CalendarContext.tsx
@@ -77,6 +77,14 @@ type PassthroughProps = {
 
   /** Size of the component */
   size?: ThemingProps<'Calendar'>['size']
+
+  /**
+   * Whether to set the calendar to always be a fixed height.
+   * This is useful for ensuring that the calendar does not jump around when the user switches between months
+   * if the months have different numbers of weeks and the calendar is positioned from the bottom.
+   * @default false
+   */
+  isCalendarFixedHeight?: boolean
 }
 
 // Removed - and _ from alphabets for simpler classnames
@@ -154,6 +162,7 @@ const useProvideCalendar = ({
   ssr,
   defaultFocusedDate,
   showOutsideDays,
+  isCalendarFixedHeight,
 }: UseProvideCalendarProps) => {
   const isMobile = useIsMobile({ ssr })
   // Ensure that calculations are always made based on date of initial render,
@@ -340,5 +349,6 @@ const useProvideCalendar = ({
     colorScheme,
     size,
     monthsToDisplay,
+    isCalendarFixedHeight,
   }
 }

--- a/react/src/Calendar/CalendarBase/CalendarContext.tsx
+++ b/react/src/Calendar/CalendarBase/CalendarContext.tsx
@@ -86,7 +86,7 @@ const nanoid = customAlphabet(
 )
 
 export interface UseProvideCalendarProps
-  extends Pick<DayzedProps, 'monthsToDisplay'>,
+  extends Pick<DayzedProps, 'monthsToDisplay' | 'showOutsideDays'>,
     PassthroughProps,
     WithSsr {
   /** The date to focus when calendar first renders. */
@@ -153,6 +153,7 @@ const useProvideCalendar = ({
   size,
   ssr,
   defaultFocusedDate,
+  showOutsideDays,
 }: UseProvideCalendarProps) => {
   const isMobile = useIsMobile({ ssr })
   // Ensure that calculations are always made based on date of initial render,
@@ -279,7 +280,7 @@ const useProvideCalendar = ({
   const renderProps = useDayzed({
     date: today,
     onDateSelected: ({ date }) => handleDateSelected(date),
-    showOutsideDays: monthsToDisplay === 1,
+    showOutsideDays: showOutsideDays ?? monthsToDisplay === 1,
     offset: getMonthOffsetFromToday(today, currMonth, currYear),
     onOffsetChanged,
     selected: !Array.isArray(selectedDates)

--- a/react/src/Calendar/CalendarBase/CalendarHeader.tsx
+++ b/react/src/Calendar/CalendarBase/CalendarHeader.tsx
@@ -128,7 +128,15 @@ export const CalendarHeader = memo(
     const {
       renderProps: { calendars, getBackProps, getForwardProps },
       size,
+      isMobile,
     } = useCalendar()
+
+    const displayNavigateButtons = useMemo(() => {
+      if (isMobile) {
+        return monthOffset === 0
+      }
+      return calendars.length - 1 === monthOffset
+    }, [calendars.length, isMobile, monthOffset])
 
     return (
       <Flex sx={styles.monthYearSelectorContainer}>
@@ -137,7 +145,7 @@ export const CalendarHeader = memo(
         ) : (
           <MonthYear monthOffset={monthOffset} />
         )}
-        {calendars.length - 1 === monthOffset ? (
+        {displayNavigateButtons ? (
           <Flex sx={styles.monthArrowContainer}>
             <IconButton
               variant="clear"

--- a/react/src/Calendar/CalendarBase/CalendarPanel.tsx
+++ b/react/src/Calendar/CalendarBase/CalendarPanel.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import {
   chakra,
   forwardRef,
@@ -22,7 +23,18 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
       dateToFocus,
       onMouseLeaveCalendar,
       renderProps: { calendars, getDateProps },
+      isCalendarFixedHeight,
     } = useCalendar()
+
+    const createFillerRows = useCallback(
+      (weeksDisplayed: number) => {
+        if (!isCalendarFixedHeight) return null
+        const weeksToFill = 6 - weeksDisplayed
+        const singleRow = <chakra.tr aria-hidden sx={styles.fillerRow} />
+        return Array.from({ length: weeksToFill }, () => singleRow)
+      },
+      [isCalendarFixedHeight, styles.fillerRow],
+    )
 
     return (
       <Stack
@@ -94,6 +106,7 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
                     </chakra.tr>
                   )
                 })}
+                {createFillerRows(calendar.weeks.length)}
               </chakra.tbody>
             </chakra.table>
             <VisuallyHidden aria-live="polite">

--- a/react/src/Calendar/CalendarBase/CalendarPanel.tsx
+++ b/react/src/Calendar/CalendarBase/CalendarPanel.tsx
@@ -39,7 +39,7 @@ export const CalendarPanel = forwardRef<{}, 'button'>(
     return (
       <Stack
         direction={{ base: 'column', md: 'row' }}
-        spacing="2rem"
+        spacing={{ md: '2rem' }}
         sx={styles.calendarContainer}
         onMouseLeave={onMouseLeaveCalendar}
       >

--- a/react/src/Calendar/CalendarBase/types.ts
+++ b/react/src/Calendar/CalendarBase/types.ts
@@ -7,6 +7,12 @@ export type CalendarBaseProps = Pick<
   | 'monthsToDisplay'
   | 'size'
   | 'defaultFocusedDate'
->
+> & {
+  /**
+   * Whether to show or hide the button to focus on Today.
+   * @default true
+   */
+  showTodayButton?: boolean
+}
 
 export type DateRangeValue = [Date, Date] | [Date, null] | [null, null]

--- a/react/src/Calendar/CalendarBase/types.ts
+++ b/react/src/Calendar/CalendarBase/types.ts
@@ -7,6 +7,7 @@ export type CalendarBaseProps = Pick<
   | 'monthsToDisplay'
   | 'size'
   | 'defaultFocusedDate'
+  | 'isCalendarFixedHeight'
 > & {
   /**
    * Whether to show or hide the button to focus on Today.

--- a/react/src/Calendar/RangeCalendar.stories.tsx
+++ b/react/src/Calendar/RangeCalendar.stories.tsx
@@ -53,6 +53,11 @@ RangeCalendarWeekdayOnly.args = {
   isDateUnavailable: (d) => isWeekend(d),
 }
 
+export const HideTodayButton = RangeCalendarOnlyTemplate.bind({})
+HideTodayButton.args = {
+  showTodayButton: false,
+}
+
 export const SizeSmall = RangeCalendarOnlyTemplate.bind({})
 SizeSmall.args = {
   size: 'sm',

--- a/react/src/Calendar/RangeCalendar.tsx
+++ b/react/src/Calendar/RangeCalendar.tsx
@@ -40,6 +40,7 @@ export const RangeCalendar = forwardRef<RangeCalendarProps, 'input'>(
       onChange,
       defaultValue = [null, null],
       monthsToDisplay = 2,
+      showTodayButton = true,
       ...props
     },
     initialFocusRef,
@@ -145,7 +146,7 @@ export const RangeCalendar = forwardRef<RangeCalendarProps, 'input'>(
           <CalendarAria />
           <Stack spacing={0} divider={<StackDivider />} sx={styles.container}>
             <CalendarPanel ref={initialFocusRef} />
-            <CalendarTodayButton />
+            {showTodayButton && <CalendarTodayButton />}
           </Stack>
         </CalendarStylesProvider>
       </CalendarProvider>

--- a/react/src/DatePicker/DatePicker.stories.tsx
+++ b/react/src/DatePicker/DatePicker.stories.tsx
@@ -40,6 +40,11 @@ DatePickerDisallowManualInput.args = {
   defaultValue: new Date('2021-09-13'),
 }
 
+export const FixedHeightCalendarPopover = Template.bind({})
+FixedHeightCalendarPopover.args = {
+  isCalendarFixedHeight: true,
+}
+
 export const SizeSmall = Template.bind({})
 SizeSmall.args = {
   size: 'sm',

--- a/react/src/DatePicker/DatePickerContext.tsx
+++ b/react/src/DatePicker/DatePickerContext.tsx
@@ -22,9 +22,11 @@ import {
 } from '@chakra-ui/react'
 import { format, isValid, parse } from 'date-fns'
 
+import { type CalendarProps } from '~/Calendar'
 import { useIsMobile } from '~/hooks'
 
 import { DatePickerProps } from './DatePicker'
+import { pickCalendarProps } from './utils'
 
 interface DatePickerContextReturn {
   isMobile: boolean
@@ -44,10 +46,16 @@ interface DatePickerContextReturn {
   allowManualInput: boolean
   colorScheme?: ThemingProps<'DatePicker'>['colorScheme']
   size?: ThemingProps<'DatePicker'>['size']
-  isDateUnavailable?: (date: Date) => boolean
   disclosureProps: UseDisclosureReturn
-  monthsToDisplay?: number
-  defaultFocusedDate?: Date
+  calendarProps: Pick<
+    CalendarProps,
+    | 'isCalendarFixedHeight'
+    | 'monthsToDisplay'
+    | 'isDateUnavailable'
+    | 'defaultFocusedDate'
+    | 'showOutsideDays'
+    | 'showTodayButton'
+  >
 }
 
 const DatePickerContext = createContext<DatePickerContextReturn | null>(null)
@@ -86,22 +94,21 @@ const useProvideDatePicker = ({
   isRequired: isRequiredProp,
   isInvalid: isInvalidProp,
   locale,
-  isDateUnavailable,
   allowManualInput = true,
   allowInvalidDates = true,
   closeCalendarOnChange = true,
   onBlur,
   onClick,
   colorScheme,
-  monthsToDisplay,
   refocusOnClose = true,
   ssr,
   size,
-  defaultFocusedDate,
   ...props
 }: DatePickerProps): DatePickerContextReturn => {
   const initialFocusRef = useRef<HTMLInputElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  const calendarProps = pickCalendarProps(props)
 
   const isMobile = useIsMobile({ ssr })
 
@@ -145,11 +152,7 @@ const useProvideDatePicker = ({
 
   const handleInputBlur: FocusEventHandler<HTMLInputElement> = useCallback(
     (e) => {
-      const date = parse(
-        internalInputValue,
-        dateFormat,
-        new Date(),
-      )
+      const date = parse(internalInputValue, dateFormat, new Date())
       // Clear if input is invalid on blur if invalid dates are not allowed.
       if (!allowInvalidDates && !isValid(date)) {
         setInternalValue(null)
@@ -204,11 +207,7 @@ const useProvideDatePicker = ({
 
   const handleInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const date = parse(
-        event.target.value,
-        dateFormat,
-        new Date(),
-      )
+      const date = parse(event.target.value, dateFormat, new Date())
       setInternalInputValue(event.target.value)
       if (isValid(date)) {
         setInternalValue(date)
@@ -256,9 +255,7 @@ const useProvideDatePicker = ({
     allowManualInput,
     colorScheme,
     size,
-    isDateUnavailable,
     disclosureProps,
-    monthsToDisplay,
-    defaultFocusedDate,
+    calendarProps,
   }
 }

--- a/react/src/DatePicker/components/DatePickerCalendar.tsx
+++ b/react/src/DatePicker/components/DatePickerCalendar.tsx
@@ -6,13 +6,11 @@ export const DatePickerCalendar = (): JSX.Element => {
   const {
     colorScheme,
     internalValue,
-    isDateUnavailable,
     handleDateChange,
     initialFocusRef,
-    monthsToDisplay,
     size,
     isMobile,
-    defaultFocusedDate,
+    calendarProps: { isCalendarFixedHeight, ...restCalendarProps },
   } = useDatePicker()
 
   const displayedSize = isMobile ? 'sm' : size
@@ -20,13 +18,12 @@ export const DatePickerCalendar = (): JSX.Element => {
   return (
     <Calendar
       size={displayedSize}
-      monthsToDisplay={monthsToDisplay}
       colorScheme={colorScheme}
       value={internalValue ?? undefined}
-      isDateUnavailable={isDateUnavailable}
       onChange={handleDateChange}
       ref={initialFocusRef}
-      defaultFocusedDate={defaultFocusedDate}
+      isCalendarFixedHeight={isMobile ? true : isCalendarFixedHeight}
+      {...restCalendarProps}
     />
   )
 }

--- a/react/src/DatePicker/types.ts
+++ b/react/src/DatePicker/types.ts
@@ -36,10 +36,4 @@ export interface DatePickerBaseProps
   refocusOnClose?: boolean
   /** date-fns's Locale of the date to be applied if provided. */
   locale?: Locale
-  /**
-   * Time zone of date created.
-   * Defaults to `'UTC'`.
-   * Accepts all possible `Intl.Locale.prototype.timeZones` values
-   */
-  timeZone?: string
 }

--- a/react/src/DatePicker/utils/index.ts
+++ b/react/src/DatePicker/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './pickCalendarProps'

--- a/react/src/DatePicker/utils/pickCalendarProps.ts
+++ b/react/src/DatePicker/utils/pickCalendarProps.ts
@@ -1,0 +1,15 @@
+import { pick } from 'lodash'
+
+import { DatePickerProps } from '../DatePicker'
+
+export const pickCalendarProps = (props: DatePickerProps) => {
+  return pick(
+    props,
+    'isCalendarFixedHeight',
+    'monthsToDisplay',
+    'isDateUnavailable',
+    'defaultFocusedDate',
+    'showOutsideDays',
+    'showTodayButton',
+  )
+}

--- a/react/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/react/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -30,6 +30,11 @@ DateRangePickerDisallowManualInput.args = {
   defaultValue: [new Date('2021-09-13'), null],
 }
 
+export const FixedHeightCalendarPopover = Template.bind({})
+FixedHeightCalendarPopover.args = {
+  isCalendarFixedHeight: true,
+}
+
 export const DatePickerInvalid = Template.bind({})
 DatePickerInvalid.args = {
   isInvalid: true,

--- a/react/src/DateRangePicker/DateRangePickerContext.tsx
+++ b/react/src/DateRangePicker/DateRangePickerContext.tsx
@@ -23,7 +23,8 @@ import {
 } from '@chakra-ui/react'
 import { format, isValid, parse } from 'date-fns'
 
-import { DateRangeValue } from '~/Calendar'
+import { DateRangeValue, RangeCalendarProps } from '~/Calendar'
+import { pickCalendarProps } from '~/DatePicker/utils'
 import { useIsMobile } from '~/hooks/useIsMobile'
 
 import { DateRangePickerProps } from './DateRangePicker'
@@ -48,12 +49,18 @@ interface DateRangePickerContextReturn {
   closeCalendarOnChange: boolean
   placeholder: string
   allowManualInput: boolean
-  isDateUnavailable?: (date: Date) => boolean
   disclosureProps: UseDisclosureReturn
   labelSeparator: string
   colorScheme?: ThemingProps<'DatePicker'>['colorScheme']
   size?: ThemingProps<'DatePicker'>['size']
-  monthsToDisplay?: number
+  calendarProps: Pick<
+    RangeCalendarProps,
+    | 'isCalendarFixedHeight'
+    | 'monthsToDisplay'
+    | 'isDateUnavailable'
+    | 'defaultFocusedDate'
+    | 'showTodayButton'
+  >
 }
 
 const DateRangePickerContext =
@@ -92,16 +99,13 @@ const useProvideDateRangePicker = ({
   isReadOnly: isReadOnlyProp,
   isRequired: isRequiredProp,
   isInvalid: isInvalidProp,
-  timeZone = 'UTC',
   locale,
-  isDateUnavailable,
   allowManualInput = true,
   allowInvalidDates = true,
   closeCalendarOnChange = true,
   onBlur,
   onClick,
   colorScheme,
-  monthsToDisplay,
   refocusOnClose = true,
   size,
   ssr,
@@ -110,6 +114,8 @@ const useProvideDateRangePicker = ({
   const initialFocusRef = useRef<HTMLInputElement>(null)
   const startInputRef = useRef<HTMLInputElement>(null)
   const endInputRef = useRef<HTMLInputElement>(null)
+
+  const calendarProps = pickCalendarProps(props)
 
   const isMobile = useIsMobile({ ssr })
 
@@ -155,9 +161,7 @@ const useProvideDateRangePicker = ({
       const [nextStart, nextEnd] = sortedRange
       if (nextStart) {
         if (isValid(nextStart)) {
-          setStartInputDisplay(
-            format(nextStart, displayFormat, { locale }),
-          )
+          setStartInputDisplay(format(nextStart, displayFormat, { locale }))
         } else if (!allowInvalidDates) {
           setStartInputDisplay('')
         }
@@ -175,7 +179,7 @@ const useProvideDateRangePicker = ({
       }
       setInternalValue(validRange)
     },
-    [allowInvalidDates, displayFormat, locale, setInternalValue, timeZone],
+    [allowInvalidDates, displayFormat, locale, setInternalValue],
   )
 
   const fcProps = useFormControlProps({
@@ -293,7 +297,6 @@ const useProvideDateRangePicker = ({
       displayFormat,
       locale,
       setInternalValue,
-      timeZone,
     ],
   )
 
@@ -337,9 +340,8 @@ const useProvideDateRangePicker = ({
     allowManualInput,
     colorScheme,
     size,
-    isDateUnavailable,
     disclosureProps,
     labelSeparator,
-    monthsToDisplay,
+    calendarProps,
   }
 }

--- a/react/src/DateRangePicker/components/DateRangePickerCalendar.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerCalendar.tsx
@@ -6,12 +6,11 @@ export const DateRangePickerCalendar = (): JSX.Element => {
   const {
     colorScheme,
     internalValue,
-    isDateUnavailable,
     handleCalendarDateChange,
     initialFocusRef,
-    monthsToDisplay,
     size,
     isMobile,
+    calendarProps: { isCalendarFixedHeight, ...restCalendarProps },
   } = useDateRangePicker()
 
   const displayedSize = isMobile ? 'sm' : size
@@ -19,12 +18,12 @@ export const DateRangePickerCalendar = (): JSX.Element => {
   return (
     <RangeCalendar
       size={displayedSize}
-      monthsToDisplay={monthsToDisplay}
       colorScheme={colorScheme}
       value={internalValue ?? undefined}
-      isDateUnavailable={isDateUnavailable}
       onChange={handleCalendarDateChange}
       ref={initialFocusRef}
+      isCalendarFixedHeight={isMobile ? false : isCalendarFixedHeight}
+      {...restCalendarProps}
     />
   )
 }

--- a/react/src/theme/components/Calendar.ts
+++ b/react/src/theme/components/Calendar.ts
@@ -18,6 +18,7 @@ const parts = anatomy('calendar').parts(
   'dayOfMonth', // container for single date
   'todayLinkContainer', // container for "Today" link,
   'todayLink', // "Today" link
+  'fillerRow', // Filler row for months with only 5 weeks displayed.
 )
 
 const { definePartsStyle, defineMultiStyleConfig } =
@@ -107,6 +108,9 @@ const xsSmStyle = definePartsStyle({
     w: '2.5rem',
     minW: '2.5rem',
   },
+  fillerRow: {
+    height: '2.75rem',
+  },
   dayNamesContainer: {
     textStyle: 'caption-1',
     color: 'base.content.default',
@@ -181,6 +185,9 @@ const sizes = {
       // components override different props.
       textStyle: 'body-1',
       ...textStyles['body-1'],
+    },
+    fillerRow: {
+      height: '3rem',
     },
   }),
 }


### PR DESCRIPTION
Closes #411

This PR adds a new prop `isCalendarFixedHeight` to the `Calendar` and `DatePicker`/`DateRangePicker` components so the calendar will not change in height on when navigating between months, resulting in poorer UX. 

Also add `showTodayButton` prop to hide or show the button.
### Before
![Recording 2023-06-26 at 16 48 34](https://github.com/opengovsg/design-system/assets/22133008/b22a3d34-037a-440f-a6e5-fcb905ae1e6e)


### After
![Recording 2023-06-26 at 16 40 42](https://github.com/opengovsg/design-system/assets/22133008/aadf1372-d6b9-4b63-bd70-568e5e46ce1e)


### Tldr; New props
```tsx
  /**
   * Whether to set the calendar to always be a fixed height.
   * This is useful for ensuring that the calendar does not jump around when the user switches between months
   * if the months have different numbers of weeks and the calendar is positioned from the bottom.
   * @default false
   */
  isCalendarFixedHeight?: boolean

  /**
   * Whether to show or hide the button to focus on Today.
   * @default true
   */
  showTodayButton?: boolean
```

This PR also improves the UX of mobile drawer for daterangepicker, reducing the spacing between months, and moving the month navigator to the first calendar. This also reduces the jumping of month navigation:

### Before
![Recording 2023-06-26 at 16 46 51](https://github.com/opengovsg/design-system/assets/22133008/5bd9e076-2d4c-4e5d-93d0-ec8bcb7a6974)



### After
![Recording 2023-06-26 at 16 45 24](https://github.com/opengovsg/design-system/assets/22133008/ea41cda6-f831-4856-94b7-41270f920752)


 