### PR TITLE
feat: allow overriding of item height in virtual list

### DIFF
--- a/react/src/MultiSelect/MultiSelect.stories.tsx
+++ b/react/src/MultiSelect/MultiSelect.stories.tsx
@@ -107,6 +107,7 @@ export const WithFixedItemHeight = Template.bind({})
 WithFixedItemHeight.args = {
   size: 'md',
   fixedItemHeight: 68,
+  defaultIsOpen: true,
   items: [
     {
       value: 'My height is 68',

--- a/react/src/MultiSelect/MultiSelect.stories.tsx
+++ b/react/src/MultiSelect/MultiSelect.stories.tsx
@@ -103,6 +103,24 @@ DisabledWithSelection.args = {
   values: ['What happens when the label is fairly long', 'Bat'],
 }
 
+export const WithFixedItemHeight = Template.bind({})
+WithFixedItemHeight.args = {
+  size: 'md',
+  fixedItemHeight: 68,
+  items: [
+    {
+      value: 'My height is 68',
+      icon: BxsCheckCircle,
+      description: 'With description',
+    },
+    {
+      value: 'Mine too',
+      icon: BxsCheckCircle,
+      description: 'With description',
+    },
+  ],
+}
+
 export const Sizes = () => {
   const items = ['sm', 'md']
   const [first, setFirst] = useState(['sm'])

--- a/react/src/MultiSelect/MultiSelectProvider.tsx
+++ b/react/src/MultiSelect/MultiSelectProvider.tsx
@@ -296,6 +296,8 @@ export const MultiSelectProvider = ({
 
   const virtualListHeight = useMemo(() => {
     const itemHeight = fixedItemHeight ?? VIRTUAL_LIST_ITEM_HEIGHT[size]
+    // If the total height is less than the max height, just return the total height.
+    // Otherwise, return the max height.
     return Math.min(filteredItems.length, 4) * itemHeight
   }, [filteredItems.length, fixedItemHeight, size])
 

--- a/react/src/MultiSelect/MultiSelectProvider.tsx
+++ b/react/src/MultiSelect/MultiSelectProvider.tsx
@@ -19,10 +19,7 @@ import {
   SelectContext,
   SharedSelectContextReturnProps,
 } from '~/SingleSelect'
-import {
-  VIRTUAL_LIST_ITEM_HEIGHT,
-  VIRTUAL_LIST_MAX_HEIGHT,
-} from '~/SingleSelect/constants'
+import { VIRTUAL_LIST_ITEM_HEIGHT } from '~/SingleSelect/constants'
 import { useItems } from '~/SingleSelect/hooks/useItems'
 import {
   defaultFilter,
@@ -68,6 +65,7 @@ export interface MultiSelectProviderProps<
    */
   downshiftMultiSelectProps?: Partial<UseMultipleSelectionProps<Item>>
   colorScheme?: ThemingProps<'MultiSelect'>['colorScheme']
+  fixedItemHeight?: number
 }
 export const MultiSelectProvider = ({
   items: rawItems,
@@ -91,6 +89,7 @@ export const MultiSelectProvider = ({
   children,
   size: _size,
   colorScheme,
+  fixedItemHeight,
 }: MultiSelectProviderProps): JSX.Element => {
   const theme = useTheme()
   // Required in case size is set in theme, we should respect the one set in theme.
@@ -296,11 +295,9 @@ export const MultiSelectProvider = ({
   })
 
   const virtualListHeight = useMemo(() => {
-    const totalHeight = filteredItems.length * VIRTUAL_LIST_ITEM_HEIGHT[size]
-    // If the total height is less than the max height, just return the total height.
-    // Otherwise, return the max height.
-    return Math.min(totalHeight, VIRTUAL_LIST_MAX_HEIGHT[size])
-  }, [filteredItems.length, size])
+    const itemHeight = fixedItemHeight ?? VIRTUAL_LIST_ITEM_HEIGHT[size]
+    return Math.min(filteredItems.length, 4) * itemHeight
+  }, [filteredItems.length, fixedItemHeight, size])
 
   return (
     <SelectContext.Provider

--- a/react/src/MultiSelect/components/MultiSelectMenu.tsx
+++ b/react/src/MultiSelect/components/MultiSelectMenu.tsx
@@ -3,7 +3,6 @@ import { List, ListItem, Portal } from '@chakra-ui/react'
 
 import { useSelectContext } from '~/SingleSelect'
 import { useSelectPopover } from '~/SingleSelect/components'
-import { VIRTUAL_LIST_OVERSCAN_HEIGHT } from '~/SingleSelect/constants'
 import { itemToValue } from '~/SingleSelect/utils'
 
 import { MultiDropdownItem } from './MultiDropdownItem'
@@ -17,7 +16,6 @@ export const MultiSelectMenu = (): JSX.Element => {
     styles,
     virtualListRef,
     virtualListHeight,
-    size,
   } = useSelectContext()
 
   const { floatingRef, floatingStyles } = useSelectPopover()
@@ -41,7 +39,7 @@ export const MultiSelectMenu = (): JSX.Element => {
           <Virtuoso
             ref={virtualListRef}
             data={items}
-            overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT[size]}
+            overscan={virtualListHeight / 2}
             style={{ height: virtualListHeight }}
             itemContent={(index, item) => {
               return (

--- a/react/src/SingleSelect/SingleSelect.stories.tsx
+++ b/react/src/SingleSelect/SingleSelect.stories.tsx
@@ -159,6 +159,9 @@ WithIconSelected.args = {
   isDisabled: false,
 }
 
+export const WithFixedItemHeight = Template.bind({})
+WithFixedItemHeight.args = { ...WithIconSelected.args, fixedItemHeight: 68 }
+
 export const WithHalfFilledValue = Template.bind({})
 WithHalfFilledValue.args = {
   comboboxProps: {

--- a/react/src/SingleSelect/SingleSelectProvider.tsx
+++ b/react/src/SingleSelect/SingleSelectProvider.tsx
@@ -38,6 +38,7 @@ export interface SingleSelectProviderProps<
   children: React.ReactNode
   /** Color scheme of component */
   colorScheme?: ThemingProps<'SingleSelect'>['colorScheme']
+  fixedItemHeight?: number
 }
 export const SingleSelectProvider = ({
   items: rawItems,
@@ -60,6 +61,7 @@ export const SingleSelectProvider = ({
   colorScheme,
   size: _size,
   comboboxProps = {},
+  fixedItemHeight,
 }: SingleSelectProviderProps): JSX.Element => {
   const theme = useTheme()
   // Required in case size is set in theme, we should respect the one set in theme.
@@ -236,11 +238,11 @@ export const SingleSelectProvider = ({
   })
 
   const virtualListHeight = useMemo(() => {
-    const totalHeight = filteredItems.length * VIRTUAL_LIST_ITEM_HEIGHT[size]
+    const itemHeight = fixedItemHeight ?? VIRTUAL_LIST_ITEM_HEIGHT[size]
     // If the total height is less than the max height, just return the total height.
     // Otherwise, return the max height.
-    return Math.min(totalHeight, VIRTUAL_LIST_MAX_HEIGHT[size])
-  }, [filteredItems.length, size])
+    return Math.min(filteredItems.length, 4) * itemHeight
+  }, [filteredItems.length, fixedItemHeight, size])
 
   return (
     <SelectContext.Provider

--- a/react/src/SingleSelect/SingleSelectProvider.tsx
+++ b/react/src/SingleSelect/SingleSelectProvider.tsx
@@ -12,7 +12,7 @@ import { useCombobox, UseComboboxProps } from 'downshift'
 import { useItems } from './hooks/useItems'
 import { defaultFilter } from './utils/defaultFilter'
 import { isItemDisabled, itemToValue } from './utils/itemUtils'
-import { VIRTUAL_LIST_ITEM_HEIGHT, VIRTUAL_LIST_MAX_HEIGHT } from './constants'
+import { VIRTUAL_LIST_ITEM_HEIGHT } from './constants'
 import { SelectContext, SharedSelectContextReturnProps } from './SelectContext'
 import { ComboboxItem } from './types'
 

--- a/react/src/SingleSelect/components/SelectMenu.tsx
+++ b/react/src/SingleSelect/components/SelectMenu.tsx
@@ -1,7 +1,6 @@
 import { Virtuoso } from 'react-virtuoso'
 import { List, ListItem, Portal } from '@chakra-ui/react'
 
-import { VIRTUAL_LIST_OVERSCAN_HEIGHT } from '../constants'
 import { useSelectContext } from '../SelectContext'
 import { itemToValue } from '../utils/itemUtils'
 
@@ -17,7 +16,6 @@ export const SelectMenu = (): JSX.Element => {
     styles,
     virtualListRef,
     virtualListHeight,
-    size,
   } = useSelectContext()
 
   const { floatingRef, floatingStyles } = useSelectPopover()
@@ -39,7 +37,7 @@ export const SelectMenu = (): JSX.Element => {
           <Virtuoso
             ref={virtualListRef}
             data={items}
-            overscan={VIRTUAL_LIST_OVERSCAN_HEIGHT[size]}
+            overscan={virtualListHeight / 2}
             style={{ height: virtualListHeight }}
             itemContent={(index, item) => {
               return (

--- a/react/src/SingleSelect/constants.ts
+++ b/react/src/SingleSelect/constants.ts
@@ -3,14 +3,3 @@ export const VIRTUAL_LIST_ITEM_HEIGHT = {
   sm: 40,
   md: 48,
 }
-
-export const VIRTUAL_LIST_MAX_HEIGHT = {
-  xs: 4 * VIRTUAL_LIST_ITEM_HEIGHT.xs,
-  sm: 4 * VIRTUAL_LIST_ITEM_HEIGHT.sm,
-  md: 4 * VIRTUAL_LIST_ITEM_HEIGHT.md,
-}
-export const VIRTUAL_LIST_OVERSCAN_HEIGHT = {
-  xs: 1.5 * VIRTUAL_LIST_ITEM_HEIGHT.xs,
-  sm: 1.5 * VIRTUAL_LIST_ITEM_HEIGHT.sm,
-  md: 1.5 * VIRTUAL_LIST_ITEM_HEIGHT.md,
-}

--- a/react/src/theme/components/SingleSelect.ts
+++ b/react/src/theme/components/SingleSelect.ts
@@ -35,7 +35,7 @@ const listBaseStyle = defineStyle((props) => {
     my: '1px',
     w: '100%',
     overflowY: 'auto',
-    maxH: '12rem',
+    maxH: 'none',
     bg: 'white',
   })
 })


### PR DESCRIPTION
## Problem

MultiSelect and SingleSelect components rely on fixed heights for items. 

```typescript
// SingleSelect/constants.ts
export const VIRTUAL_LIST_ITEM_HEIGHT = {
  xs: 40,
  sm: 40,
  md: 48,
}
```

However, when descriptions are added, item height exceed fixed constant and overflows the computed virtualListHeight.

```typescript
export const VIRTUAL_LIST_MAX_HEIGHT = {
  xs: 4 * VIRTUAL_LIST_ITEM_HEIGHT.xs,
  sm: 4 * VIRTUAL_LIST_ITEM_HEIGHT.sm,
  md: 4 * VIRTUAL_LIST_ITEM_HEIGHT.md,
}
```

E.g. list becomes scrollable with only one item

![image](https://github.com/opengovsg/design-system/assets/10072985/9aea3bb0-87d5-471a-ae57-32aeffa63146)

## Solution

Allow overriding of list item height.

![image](https://github.com/opengovsg/design-system/assets/10072985/8d25f124-5665-4814-9ac1-0d4ceace2c09)
