### PR TITLE
fix: label typing tooltip to match chakra

### DIFF
--- a/react/src/Tooltip/Tooltip.tsx
+++ b/react/src/Tooltip/Tooltip.tsx
@@ -9,10 +9,6 @@ import {
 
 export interface TooltipProps extends ChakraTooltipProps {
   /**
-   * Text which appears on hover/focus.
-   */
-  label: React.ReactNode
-  /**
    * Styles for the container which wraps the children.
    */
   wrapperStyles?: SystemStyleObject

--- a/react/src/Tooltip/Tooltip.tsx
+++ b/react/src/Tooltip/Tooltip.tsx
@@ -11,7 +11,7 @@ export interface TooltipProps extends ChakraTooltipProps {
   /**
    * Text which appears on hover/focus.
    */
-  label: string
+  label: React.ReactNode
   /**
    * Styles for the container which wraps the children.
    */


### PR DESCRIPTION
## Problem

Tooltip label typing (`string`) is more restrictive from Chakra's. This makes it harder to control the label that is displayed when the tool tip is opened.

## Solution

**Improvements**:

- Update label typing to be the same as that on Chakra

## Tests

- [ ] Pass in text for the label prop. It should render properly.
- [ ] Pass in a React Element for the label prop. It should render properly.
