### PR TITLE
fix(searchbar): clear controlled searchbar

### DIFF
--- a/react/src/Searchbar/Searchbar.stories.tsx
+++ b/react/src/Searchbar/Searchbar.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Box, Flex, Stack, Text } from '@chakra-ui/react'
 import { Meta, StoryFn } from '@storybook/react'
 
@@ -33,6 +34,23 @@ ExpandableOpen.args = {
   defaultValue: 'Search field filled',
 }
 ExpandableOpen.storyName = 'Expandable/Open'
+
+export const Controlled: StoryFn<SearchbarProps> = (args) => {
+  const [state, setState] = useState<string>('')
+  return (
+    <Stack direction="column" align="flex-start">
+      <Text>External State: {state}</Text>
+      <Searchbar
+        {...args}
+        value={state}
+        onChange={(e) => setState(e.target.value)}
+      />
+    </Stack>
+  )
+}
+Controlled.args = {
+  defaultIsExpanded: true,
+}
 
 export const Sizes: StoryFn<SearchbarProps> = (args) => {
   return (

--- a/react/src/Searchbar/Searchbar.tsx
+++ b/react/src/Searchbar/Searchbar.tsx
@@ -67,6 +67,7 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
   (
     {
       onSearch,
+      onChange,
       defaultIsExpanded,
       isExpanded: isExpandedProp,
       onExpansion: onExpansionProp,
@@ -103,6 +104,11 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
     )
 
     const handleClearButtonClick = useCallback(() => {
+      if (onChange) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        onChange({ target: { value: '' } })
+      }
       if (innerRef.current) {
         innerRef.current.value = ''
       }
@@ -110,7 +116,7 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
         onExpansion(false)
       }
       innerRef.current?.focus()
-    }, [collapseOnClear, onExpansion])
+    }, [onChange, collapseOnClear, onExpansion])
 
     const handleExpansion = useCallback(() => {
       onExpansion(true)
@@ -146,6 +152,7 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
           ref={inputRef}
           sx={styles.field}
           onKeyDown={handleSearch}
+          onChange={onChange}
           {...props}
         />
         {showClearButton && isExpanded && (

--- a/react/src/Searchbar/Searchbar.tsx
+++ b/react/src/Searchbar/Searchbar.tsx
@@ -66,8 +66,10 @@ export interface SearchbarProps extends InputProps {
 export const Searchbar = forwardRef<SearchbarProps, 'input'>(
   (
     {
+      defaultValue: defaultValueProp,
+      value: valueProp,
+      onChange: onChangeProp,
       onSearch,
-      onChange,
       defaultIsExpanded,
       isExpanded: isExpandedProp,
       onExpansion: onExpansionProp,
@@ -79,6 +81,17 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
     },
     ref,
   ) => {
+    const [value, onChange] = useControllableState<string>({
+      defaultValue:
+        defaultValueProp === undefined ? '' : String(defaultValueProp),
+      value: valueProp === undefined ? undefined : String(valueProp),
+      onChange: onChangeProp
+        ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          (value) => onChangeProp({ target: { value } })
+        : undefined,
+    })
+
     const [isExpanded, onExpansion] = useControllableState({
       defaultValue: defaultIsExpanded,
       value: isExpandedProp,
@@ -96,22 +109,15 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
 
     const handleSearch = useCallback(
       (e: KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter' && innerRef.current && onSearch) {
-          onSearch(innerRef.current.value)
+        if (e.key === 'Enter' && onSearch) {
+          onSearch(value)
         }
       },
-      [onSearch],
+      [value, onSearch],
     )
 
     const handleClearButtonClick = useCallback(() => {
-      if (onChange) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        onChange({ target: { value: '' } })
-      }
-      if (innerRef.current) {
-        innerRef.current.value = ''
-      }
+      onChange('')
       if (collapseOnClear) {
         onExpansion(false)
       }
@@ -152,7 +158,8 @@ export const Searchbar = forwardRef<SearchbarProps, 'input'>(
           ref={inputRef}
           sx={styles.field}
           onKeyDown={handleSearch}
-          onChange={onChange}
+          onChange={(e) => onChange(e.target.value)}
+          value={value}
           {...props}
         />
         {showClearButton && isExpanded && (


### PR DESCRIPTION
## Problem

Support for controlled searchbars was introduced in #218. However, the clear button does not trigger the `onChange` function and only supports uncontrolled inputs.

Closes #446 

## Solution

Check if the searchbar is a controlled input by checking for the presence of `onChange`. If it is a controlled input, call `onChange` with the appropriate value.

## Tests

- [x] Includes new story for controlled searchbar input.
