### PR TITLE
feat: add success variant for infobox component

### DIFF
--- a/react/src/Infobox/Infobox.stories.tsx
+++ b/react/src/Infobox/Infobox.stories.tsx
@@ -50,23 +50,17 @@ CustomIcon.args = {
 
 export const Sizes = () => (
   <SimpleGrid columns={2} gap="1rem">
-    <Infobox variant="info" size="sm" height="fit-content">
-      Small info
-    </Infobox>
-    <Infobox variant="info" size="md" height="fit-content">
-      Medium info
-    </Infobox>
-    <Infobox variant="warning" size="sm" height="fit-content">
-      Small warning
-    </Infobox>
-    <Infobox variant="warning" size="md" height="fit-content">
-      Medium warning
-    </Infobox>
-    <Infobox variant="error" size="sm" height="fit-content">
-      Small error
-    </Infobox>
-    <Infobox variant="error" size="md" height="fit-content">
-      Medium error
-    </Infobox>
+    {['info', 'warning', 'error', 'success'].map((variant) =>
+      ['sm', 'md'].map((size) => (
+        <Infobox
+          key={`${variant}-${size}`}
+          variant={variant as InfoboxProps['variant']}
+          size={size}
+          height="fit-content"
+        >
+          {`${size === 'sm' ? 'Small' : 'Medium'} ${variant}`}
+        </Infobox>
+      )),
+    )}
   </SimpleGrid>
 )

--- a/react/src/Infobox/Infobox.stories.tsx
+++ b/react/src/Infobox/Infobox.stories.tsx
@@ -35,6 +35,12 @@ Error.args = {
   children: `Only 30 MyInfo fields are allowed in Email mode (30/30).`,
 }
 
+export const Success = InfoboxTemplate.bind({})
+Success.args = {
+  variant: 'success',
+  children: `You are your mother's proudest moment.`,
+}
+
 export const CustomIcon = InfoboxTemplate.bind({})
 CustomIcon.args = {
   variant: 'info',

--- a/react/src/Infobox/Infobox.tsx
+++ b/react/src/Infobox/Infobox.tsx
@@ -8,7 +8,7 @@ import {
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
-import { BxsErrorCircle, BxsInfoCircle } from '~/icons'
+import { BxsCheckCircle, BxsErrorCircle, BxsInfoCircle } from '~/icons'
 import { InfoboxVariant } from '~/theme/components/Infobox'
 
 export interface InfoboxProps extends FlexProps {
@@ -39,12 +39,13 @@ export const Infobox = ({
     if (iconProp) {
       return <Box __css={styles.icon}>{iconProp}</Box>
     }
-    return (
-      <Icon
-        as={variant !== 'error' ? BxsInfoCircle : BxsErrorCircle}
-        __css={styles.icon}
-      />
-    )
+    if (variant === 'error') {
+      return <Icon as={BxsErrorCircle} __css={styles.icon} />
+    }
+    if (variant === 'success') {
+      return <Icon as={BxsCheckCircle} __css={styles.icon} />
+    }
+    return <Icon as={BxsInfoCircle} __css={styles.icon} />
   }, [iconProp, styles.icon, variant])
 
   return (

--- a/react/src/theme/components/Infobox.ts
+++ b/react/src/theme/components/Infobox.ts
@@ -1,7 +1,7 @@
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 import { anatomy } from '@chakra-ui/theme-tools'
 
-export type InfoboxVariant = 'info' | 'error' | 'warning'
+export type InfoboxVariant = 'info' | 'error' | 'warning' | 'success'
 
 const parts = anatomy('infobox').parts('messagebox', 'icon')
 
@@ -43,6 +43,15 @@ const variantError = definePartsStyle({
   },
 })
 
+const variantSuccess = definePartsStyle({
+  messagebox: {
+    bg: 'utility.feedback.success-subtle',
+  },
+  icon: {
+    color: 'utility.feedback.success',
+  },
+})
+
 const sizes = {
   sm: definePartsStyle({
     messagebox: {
@@ -71,6 +80,7 @@ const variants = {
   info: variantInfo,
   warning: variantWarning,
   error: variantError,
+  success: variantSuccess,
 }
 
 export const Infobox = defineMultiStyleConfig({


### PR DESCRIPTION
## Problem

Current infobox only has 'info', 'warning', 'error' variants but no success.

## Solution

Add 'success' variant.

<img width="888" alt="Screenshot 2023-08-22 at 6 29 12 PM" src="https://github.com/opengovsg/design-system/assets/10072985/8cdb1223-a1f1-47c0-a970-c0be172068ea">

