### PR TITLE
feat: remove explicit variant type declarations in component props

### DIFF
--- a/react/src/Badge/Badge.tsx
+++ b/react/src/Badge/Badge.tsx
@@ -8,18 +8,11 @@ import {
   useStyleConfig,
 } from '@chakra-ui/react'
 
-import { BadgeVariants } from '~/theme/components/Badge'
-
 const [BadgeStylesProvider, useBadgeStyles] = createStylesContext('Badge')
 
 export { useBadgeStyles }
 
-export interface BadgeProps extends ChakraBadgeProps {
-  /**
-   * The theme of the tag to display
-   */
-  variant?: BadgeVariants
-}
+export interface BadgeProps extends ChakraBadgeProps {}
 
 export const Badge = (props: BadgeProps): JSX.Element => {
   const styles = useStyleConfig('Badge', props)

--- a/react/src/Banner/Banner.tsx
+++ b/react/src/Banner/Banner.tsx
@@ -6,15 +6,15 @@ import {
   Collapse,
   Flex,
   Icon,
+  ThemingProps,
   useDisclosure,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
 import { BxsErrorCircle, BxsInfoCircle, BxX } from '~/icons'
-import { BannerVariant } from '~/theme/components/Banner'
 
 export interface BannerProps {
-  variant?: BannerVariant
+  variant?: ThemingProps<'Banner'>['variant']
   children: React.ReactNode
   /**
    * Whether to allow collapsing of the banner.

--- a/react/src/Button/Button.tsx
+++ b/react/src/Button/Button.tsx
@@ -7,17 +7,9 @@ import {
 } from '@chakra-ui/react'
 
 import { Spinner } from '~/Spinner'
-import {
-  ThemeButtonColorScheme,
-  ThemeButtonVariant,
-} from '~/theme/components/Button'
+import { ThemeButtonColorScheme } from '~/theme/components/Button'
 
 export interface ButtonProps extends ChakraButtonProps {
-  /**
-   * The variant of the button.
-   */
-  variant?: ThemeButtonVariant
-
   /**
    * Specifies whether the button is full-width.
    * If so, set button width to 100%, height to auto and padding to 15px

--- a/react/src/FormControl/FormHelperText/FormHelperText.tsx
+++ b/react/src/FormControl/FormHelperText/FormHelperText.tsx
@@ -3,6 +3,7 @@ import {
   FormHelperText as ChakraFormHelperText,
   FormHelperTextProps as ChakraFormHelperTextProps,
   Icon,
+  ThemingProps,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 import { merge } from 'lodash'
@@ -11,9 +12,9 @@ import { BxsCheckCircle } from '~/icons'
 
 export interface FormHelperTextProps extends ChakraFormHelperTextProps {
   /**
-   * Variant of input message, determines the styling. Defaults to `info`.
+   * Variant of input message, determines the styling.
    */
-  variant?: 'success' | 'info'
+  variant?: ThemingProps<'Form'>['variant']
 }
 
 /**

--- a/react/src/IconButton/IconButton.tsx
+++ b/react/src/IconButton/IconButton.tsx
@@ -7,20 +7,13 @@ import {
 } from '@chakra-ui/react'
 
 import { Spinner } from '~/Spinner'
-import {
-  ThemeButtonColorScheme,
-  ThemeButtonVariant,
-} from '~/theme/components/Button'
+import { ThemeButtonColorScheme } from '~/theme/components/Button'
 
 export interface IconButtonProps extends ChakraIconButtonProps {
   /**
    * Size of the icon button.
    */
   size?: ThemingProps<'Button'>['size']
-  /**
-   * The variant of the button.
-   */
-  variant?: ThemeButtonVariant
 
   /**
    * Color scheme of button.

--- a/react/src/Infobox/Infobox.tsx
+++ b/react/src/Infobox/Infobox.tsx
@@ -9,11 +9,10 @@ import {
 } from '@chakra-ui/react'
 
 import { BxsCheckCircle, BxsErrorCircle, BxsInfoCircle } from '~/icons'
-import { InfoboxVariant } from '~/theme/components/Infobox'
 
 export interface InfoboxProps extends FlexProps {
   size?: ThemingProps<'Infobox'>['size']
-  variant?: InfoboxVariant
+  variant?: ThemingProps<'Infobox'>['variant']
   /**
    * The content of the infobox.
    */

--- a/react/src/Menu/Menu.tsx
+++ b/react/src/Menu/Menu.tsx
@@ -7,15 +7,15 @@ import {
   MenuItem as ChakraMenuItem,
   MenuList as ChakraMenuList,
   MenuProps as ChakraMenuProps,
+  ThemingProps,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
 import { Button, ButtonProps } from '~/Button'
 import { BxsChevronDown, BxsChevronUp } from '~/icons'
-import { MenuVariant } from '~/theme/components/Menu'
 
 export interface MenuButtonProps extends Omit<ButtonProps, 'isFullWidth'> {
-  variant?: MenuVariant
+  variant?: ThemingProps<'Menu'>['variant']
   isStretch?: boolean
   isOpen?: boolean
   chevronSize?: string

--- a/react/src/RestrictedFooter/common/types.ts
+++ b/react/src/RestrictedFooter/common/types.ts
@@ -2,6 +2,7 @@ import {
   FlexProps,
   ResponsiveValue,
   StyleFunctionProps,
+  ThemingProps,
 } from '@chakra-ui/react'
 import { SetOptional } from 'type-fest'
 
@@ -48,7 +49,7 @@ export interface RestrictedFooterProps
     >,
     WithSsr {
   /**
-   * The footer variant to display. Defaults to `full` if not provided.
+   * The footer variant to display.
    */
-  variant?: ResponsiveValue<'full' | 'compact'>
+  variant?: ThemingProps<'Footer'>['variant']
 }

--- a/react/src/Tile/Tile.tsx
+++ b/react/src/Tile/Tile.tsx
@@ -50,7 +50,7 @@ export interface TileProps
   /**
    * The variant of the tile - whether it is complex (many elements) or simple (title and subtitle only).
    */
-  variant: ThemingProps<'Tile'>['variant']
+  variant?: ThemingProps<'Tile'>['variant']
 
   /**
    * Whether the tile is selected or not

--- a/react/src/theme/components/Badge.ts
+++ b/react/src/theme/components/Badge.ts
@@ -5,8 +5,6 @@ import { getContrastColor } from '~/theme/utils/contrast'
 
 import { textStyles } from '../textStyles'
 
-export type BadgeVariants = 'solid' | 'subtle' | 'clear'
-
 const baseStyle = defineStyle({
   ...textStyles['caption-1'],
   textTransform: 'initial',

--- a/react/src/theme/components/Banner.ts
+++ b/react/src/theme/components/Banner.ts
@@ -3,8 +3,6 @@ import { anatomy } from '@chakra-ui/theme-tools'
 
 import { layerStyles } from '../layerStyles'
 
-export type BannerVariant = 'info' | 'error' | 'warn'
-
 const parts = anatomy('banner').parts('banner', 'item', 'icon', 'link', 'close')
 
 const { definePartsStyle, defineMultiStyleConfig } =

--- a/react/src/theme/components/Button.ts
+++ b/react/src/theme/components/Button.ts
@@ -9,14 +9,6 @@ import { hexToRgba } from '../utils/hexToRgba'
 
 import { Link } from './Link'
 
-export type ThemeButtonVariant =
-  | 'solid'
-  | 'reverse'
-  | 'outline'
-  | 'clear'
-  | 'link'
-  | 'inputAttached'
-
 export type ThemeButtonColorScheme =
   | 'main'
   | 'success'

--- a/react/src/theme/components/Infobox.ts
+++ b/react/src/theme/components/Infobox.ts
@@ -1,8 +1,6 @@
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 import { anatomy } from '@chakra-ui/theme-tools'
 
-export type InfoboxVariant = 'info' | 'error' | 'warning' | 'success'
-
 const parts = anatomy('infobox').parts('messagebox', 'icon')
 
 const { definePartsStyle, defineMultiStyleConfig } =

--- a/react/src/theme/components/Menu.ts
+++ b/react/src/theme/components/Menu.ts
@@ -7,8 +7,6 @@ const parts = menuAnatomy.extend('chevron')
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
-export type MenuVariant = 'outline' | 'clear'
-
 const $bg = cssVar('menu-bg')
 const $shadow = cssVar('menu-shadow')
 


### PR DESCRIPTION
When users of OGPDS adds variants to certain components, the component's `variant` prop does not update to the new available variants, affecting intellisense and forcing users to ignore the invalid typescript type error. This PR removes all explicit variant type declarations and use `ThemingProps<Component>['variant']` as the type instead, so the types updates properly when `chakra-cli` is run.