### PR TITLE
feat(theme): use `utility.ui` token instead of hardcoding "white"

### DIFF
--- a/react/src/Button/Button.stories.tsx
+++ b/react/src/Button/Button.stories.tsx
@@ -9,9 +9,6 @@ export default {
   title: 'Components/Button',
   component: Button,
   tags: ['autodocs'],
-  parameters: {
-    backgrounds: { default: 'light' },
-  },
 } as Meta
 
 const ButtonTemplate: StoryFn<ButtonProps> = (args) => <Button {...args} />

--- a/react/src/DatePicker/components/DatePickerContent.tsx
+++ b/react/src/DatePicker/components/DatePickerContent.tsx
@@ -19,6 +19,7 @@ export const DatePickerContent = ({
       size={size}
       isMobile={isMobile}
       headerStyles={styles.header}
+      containerStyles={styles.container}
       isOpen={isOpen}
       onClose={onClose}
       initialFocusRef={initialFocusRef}

--- a/react/src/DatePicker/components/DatePickerContentBase.tsx
+++ b/react/src/DatePicker/components/DatePickerContentBase.tsx
@@ -23,6 +23,7 @@ interface DatePickerContentBaseProps {
   onClose: () => void
   initialFocusRef: React.RefObject<HTMLElement>
   headerStyles?: SystemStyleObject
+  containerStyles?: SystemStyleObject
   size: ThemingProps<'DatePicker'>['size']
 }
 
@@ -32,6 +33,7 @@ export const DatePickerContentBase = ({
   isOpen,
   onClose,
   headerStyles,
+  containerStyles,
   initialFocusRef,
   size,
 }: DatePickerContentBaseProps): JSX.Element => {
@@ -44,7 +46,7 @@ export const DatePickerContentBase = ({
         initialFocusRef={initialFocusRef}
       >
         <DrawerOverlay />
-        <DrawerContent maxH="100%" overflow="auto">
+        <DrawerContent sx={containerStyles} maxH="100%" overflow="auto">
           <DrawerCloseButton
             size="sm"
             right="0.625rem"
@@ -62,7 +64,12 @@ export const DatePickerContentBase = ({
 
   return (
     <Portal>
-      <PopoverContent borderRadius="base" w="unset" maxW="100vw" bg="white">
+      <PopoverContent
+        borderRadius="base"
+        w="unset"
+        maxW="100vw"
+        sx={containerStyles}
+      >
         <ReactFocusLock>
           <PopoverHeader sx={headerStyles}>
             Select a date

--- a/react/src/DateRangePicker/components/DateRangePickerContent.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerContent.tsx
@@ -23,6 +23,7 @@ export const DateRangePickerContent = ({
       onClose={onClose}
       initialFocusRef={initialFocusRef}
       headerStyles={styles.header}
+      containerStyles={styles.container}
     >
       {children}
     </DatePickerContentBase>

--- a/react/src/MultiSelect/components/MultiDropdownItem/ItemCheckboxIcon.tsx
+++ b/react/src/MultiSelect/components/MultiDropdownItem/ItemCheckboxIcon.tsx
@@ -6,29 +6,24 @@ import { BxCheckAnimated } from '~/icons'
 
 type ItemCheckboxIconProps = Pick<
   CheckboxProps,
-  'isChecked' | 'isDisabled' | 'size'
+  'isChecked' | 'isDisabled' | 'size' | 'sx'
 >
 
 export const ItemCheckboxIcon = ({
   isChecked,
   isDisabled,
   size,
+  sx,
 }: ItemCheckboxIconProps): JSX.Element => {
   const styles = useMultiStyleConfig('Checkbox', { size })
 
   return (
     <Box
-      display="inline-flex"
-      alignItems="center"
-      justifyContent="center"
-      verticalAlign="top"
       userSelect="none"
-      flexShrink={0}
-      bg="white"
       __css={styles.control}
       data-checked={dataAttr(isChecked)}
+      sx={sx}
       aria-disabled={isDisabled}
-      borderColor="base.content.strong"
     >
       <Icon as={BxCheckAnimated} __css={styles.icon} isChecked={isChecked} />
     </Box>

--- a/react/src/MultiSelect/components/MultiDropdownItem/MultiDropdownItem.tsx
+++ b/react/src/MultiSelect/components/MultiDropdownItem/MultiDropdownItem.tsx
@@ -57,6 +57,7 @@ export const MultiDropdownItem = ({
         <ItemCheckboxIcon
           isDisabled={isDisabled}
           isChecked={isSelected}
+          sx={styles.checkContainer}
           size={size}
         />
         <Flex flexDir="column" minW={0}>

--- a/react/src/Toolbar/Toolbar.stories.tsx
+++ b/react/src/Toolbar/Toolbar.stories.tsx
@@ -39,6 +39,11 @@ const Template: StoryFn<ToolbarProps> = ({ children, ...args }) => {
 }
 export const TemplateExample = Template.bind({})
 
+export const MainColorScheme = Template.bind({})
+MainColorScheme.args = {
+  colorScheme: 'main',
+}
+
 export const NeutralColorScheme = Template.bind({})
 NeutralColorScheme.args = {
   colorScheme: 'neutral',

--- a/react/src/theme/components/Attachment.ts
+++ b/react/src/theme/components/Attachment.ts
@@ -49,7 +49,7 @@ const baseStyle = definePartsStyle({
   fileInfoImage: {
     borderRight: '1px solid',
     borderColor: 'inherit',
-    bg: 'white',
+    bg: 'utility.ui',
   },
 })
 

--- a/react/src/theme/components/Button.ts
+++ b/react/src/theme/components/Button.ts
@@ -150,12 +150,12 @@ const variantReverse = defineStyle((props) => {
   const { hoverBg, activeBg, color } = genVariantReverseColours(props)
 
   return {
-    bg: 'white',
+    bg: 'utility.ui',
     borderColor: 'transparent',
     color,
     px: '15px',
     _disabled: {
-      bg: 'white',
+      bg: 'utility.ui',
       borderColor: 'transparent',
     },
     _active: {
@@ -164,7 +164,7 @@ const variantReverse = defineStyle((props) => {
     _hover: {
       bg: hoverBg,
       _disabled: {
-        bg: 'white',
+        bg: 'utility.ui',
       },
     },
   }

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -26,31 +26,31 @@ const getColorProps = (props: StyleFunctionProps) => {
   switch (c) {
     case 'main':
       return {
-        bg: mode('white', 'transparent')(props),
+        bg: mode('utility.ui', 'transparent')(props),
         checkedBg: 'interaction.main.default',
         iconColor: 'white',
         hoverBg: mode(
           'interaction.muted.main.hover',
           'interaction.tinted.main.active',
         )(props),
-        borderColor: mode('interaction.main.default', 'white')(props),
+        borderColor: mode('interaction.main.default', 'utility.ui')(props),
         labelColor: mode('base.content.default', 'base.content.inverse')(props),
       }
     // Inverse color scheme, used for darker backgrounds.
     case 'inverse':
       return {
         bg: 'transparent',
-        checkedBg: 'white',
+        checkedBg: 'utility.ui',
         iconColor: 'base.content.strong',
         hoverBg: 'interaction.tinted.inverse.hover',
-        borderColor: 'white',
+        borderColor: 'utility.ui',
         labelColor: 'base.content.inverse',
       }
     default: {
       return {
-        bg: mode('white', 'transparent')(props),
+        bg: mode('utility.ui', 'transparent')(props),
         checkedBg: `${c}.500`,
-        iconColor: 'white',
+        iconColor: 'utility.ui',
         hoverBg: `${c}.100`,
         borderColor: `${c}.500`,
         labelColor: mode('base.content.default', 'base.content.inverse')(props),

--- a/react/src/theme/components/DatePicker.ts
+++ b/react/src/theme/components/DatePicker.ts
@@ -6,6 +6,7 @@ import { textStyles } from '../textStyles'
 export const datepickerAnatomy = anatomy('datepicker').parts(
   'header',
   'inputButton',
+  'container',
 )
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(datepickerAnatomy.keys)
@@ -30,6 +31,9 @@ const sizes = {
 
 export const DatePicker = defineMultiStyleConfig({
   baseStyle: {
+    container: {
+      bg: 'utility.ui',
+    },
     header: {
       h: '3.5rem',
       display: 'flex',

--- a/react/src/theme/components/Menu.ts
+++ b/react/src/theme/components/Menu.ts
@@ -41,15 +41,17 @@ const baseStyle = definePartsStyle((props) => {
       borderRadius: 0,
       minWidth: '0rem',
       [$shadow.variable]: 'shadows.sm',
+      [$bg.variable]: 'colors.utility.ui',
       boxShadow: $shadow.reference,
     },
     item: {
       bg: $bg.reference,
+      [$bg.variable]: 'colors.utility.ui',
       textStyle: 'body-1',
       fontWeight: '400',
       color: 'base.content.strong',
       _hover: {
-        bg: hoverBg,
+        [$bg.variable]: `colors.${hoverBg}`,
       },
       _disabled: {
         color: 'interaction.support.disabled-content',

--- a/react/src/theme/components/Menu.ts
+++ b/react/src/theme/components/Menu.ts
@@ -45,6 +45,8 @@ const baseStyle = definePartsStyle((props) => {
       boxShadow: $shadow.reference,
     },
     item: {
+      // Required for items to also have variable colors
+      bg: $bg.reference,
       [$bg.variable]: 'colors.utility.ui',
       textStyle: 'body-1',
       fontWeight: '400',

--- a/react/src/theme/components/Menu.ts
+++ b/react/src/theme/components/Menu.ts
@@ -45,7 +45,6 @@ const baseStyle = definePartsStyle((props) => {
       boxShadow: $shadow.reference,
     },
     item: {
-      bg: $bg.reference,
       [$bg.variable]: 'colors.utility.ui',
       textStyle: 'body-1',
       fontWeight: '400',

--- a/react/src/theme/components/Modal.ts
+++ b/react/src/theme/components/Modal.ts
@@ -18,6 +18,7 @@ const baseStyleDialog = defineStyle((props) => {
     my: '8rem',
     maxH: scrollBehavior === 'inside' ? 'calc(100% - 16rem)' : undefined,
     boxShadow: 'md',
+    bg: 'utility.ui',
   }
 })
 

--- a/react/src/theme/components/MultiSelect.ts
+++ b/react/src/theme/components/MultiSelect.ts
@@ -16,6 +16,7 @@ export const parts = anatomy('multiselect').parts(
   'chevron',
   'fieldwrapper',
   'itemContainer',
+  'checkContainer',
 )
 
 const { definePartsStyle, defineMultiStyleConfig } =
@@ -50,6 +51,15 @@ const baseStyle = definePartsStyle((props) => {
     icon: {
       display: 'inline-flex',
       h: 'fit-content',
+    },
+    checkContainer: {
+      flexShrink: 0,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      verticalAlign: 'top',
+      borderColor: 'base.content.strong',
+      bg: 'utility.ui',
     },
     tagIcon: {
       display: 'inline-flex',

--- a/react/src/theme/components/PhoneNumberInput.ts
+++ b/react/src/theme/components/PhoneNumberInput.ts
@@ -25,7 +25,7 @@ const outlineVariant = definePartsStyle((props) => {
     country: {
       transitionProperty: 'common',
       transitionDuration: 'normal',
-      bg: 'white',
+      bg: 'utility.ui',
       border: '1px solid',
       borderColor: 'base.divider.strong',
       _disabled: {

--- a/react/src/theme/components/SingleSelect.ts
+++ b/react/src/theme/components/SingleSelect.ts
@@ -36,7 +36,7 @@ const listBaseStyle = defineStyle((props) => {
     w: '100%',
     overflowY: 'auto',
     maxH: 'none',
-    bg: 'white',
+    bg: 'utility.ui',
   })
 })
 

--- a/react/src/theme/components/Toolbar.ts
+++ b/react/src/theme/components/Toolbar.ts
@@ -21,7 +21,7 @@ const getSolidVariantContainerStyles = (c: string) => {
     case 'main':
       return {
         bg: `interaction.${c}.default`,
-        color: 'white',
+        color: 'utility.ui',
       }
     case 'neutral':
       return {


### PR DESCRIPTION
"white" was used for the color token of many components in the design system. When a theme is by default dark mode, like PinPoint, many components break. This PR changes the declaration of "white" to `utility.ui` design token wherever it made sense, to unbreak themes like PinPoint.

This PR also allows for theme overrides for:
* DatePicker and DateRangePicker's calendar container via `styles.container` prop, and
* MultiSelect's menu list's check container via `styles.checkContainer` prop.

so custom themes can override styling for the relevant date picker and multiselect containers.

Previously, the background for the datepicker calendar container was hardcoded. it now takes the theme's `container` styles.

Chromatic should have no differences

## Before
(pinpoint theme)
![Screenshot 2023-09-15 at 9 23 25 PM](https://github.com/opengovsg/design-system/assets/22133008/36cd7b61-7404-4211-8460-88552b588358)

## After
![Screenshot 2023-09-15 at 9 24 22 PM](https://github.com/opengovsg/design-system/assets/22133008/c403836a-02ab-477f-abb6-36b0cf989782)



