### PR TITLE
feat(attachment): correctly set default args in story

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -12,7 +12,6 @@
         "@chakra-ui/utils": "^2.0.12",
         "@floating-ui/react": "^0.25.2",
         "@fontsource/ibm-plex-mono": "^5.0.3",
-        "@swc/core-linux-x64-gnu": "^1.3.37",
         "country-flag-icons": "^1.4.19",
         "date-fns": "^2.28.0",
         "dayzed": "^3.2.3",

--- a/react/src/Attachment/Attachment.stories.tsx
+++ b/react/src/Attachment/Attachment.stories.tsx
@@ -23,7 +23,7 @@ export default {
   component: Attachment,
   tags: ['autodocs'],
   decorators: [],
-  parameters: {
+  args: {
     name: 'Test-input',
     maxSize: 23000,
   },


### PR DESCRIPTION
Attachment stories had regression due to adding default args to `parameters` object instead of `args`. Also highlights the importance of running chromatic on package updates...