### PR TITLE
fix: type button and refactor SectionWrapper

### DIFF
--- a/react/src/Sidebar/SidebarList.tsx
+++ b/react/src/Sidebar/SidebarList.tsx
@@ -71,13 +71,11 @@ const SectionWrapper: FC<PropsWithChildren & SectionWrapperProps> = ({
     </chakra.button>
   )
 }
-
-type ToggleChevronWrapperProps = HTMLChakraProps<'button'> &
-  HTMLChakraProps<'div'> & { onlyCaretToggle: boolean }
-
-const ToggleChevronWrapper: FC<
-  PropsWithChildren & ToggleChevronWrapperProps
-> = ({ children, onlyCaretToggle, ...props }) => {
+const ToggleChevronWrapper: FC<PropsWithChildren & SectionWrapperProps> = ({
+  children,
+  onlyCaretToggle,
+  ...props
+}) => {
   if (onlyCaretToggle)
     return (
       <chakra.button {...props} type="button">

--- a/react/src/Sidebar/SidebarList.tsx
+++ b/react/src/Sidebar/SidebarList.tsx
@@ -72,6 +72,22 @@ const SectionWrapper: FC<PropsWithChildren & SectionWrapperProps> = ({
   )
 }
 
+type ToggleChevronWrapperProps = HTMLChakraProps<'button'> &
+  HTMLChakraProps<'div'> & { onlyCaretToggle: boolean }
+
+const ToggleChevronWrapper: FC<
+  PropsWithChildren & ToggleChevronWrapperProps
+> = ({ children, onlyCaretToggle, ...props }) => {
+  if (onlyCaretToggle)
+    return (
+      <chakra.button {...props} type="button">
+        {children}
+      </chakra.button>
+    )
+
+  return <chakra.div {...props}>{children}</chakra.div>
+}
+
 export const SidebarList = forwardRef<
   PropsWithChildren<SidebarListProps>,
   'li'
@@ -122,11 +138,6 @@ export const SidebarList = forwardRef<
       return merge({}, mergedStyles, { cursor: 'pointer' })
     }, [onlyCaretToggle, styles.item, styles.parent])
 
-    const ToggleChevronWrapper = useMemo(() => {
-      if (onlyCaretToggle) return chakra.button
-      return chakra.div
-    }, [onlyCaretToggle])
-
     return (
       <chakra.li __css={styles.list} pl={0} ref={ref} {...props}>
         <Box>
@@ -143,12 +154,14 @@ export const SidebarList = forwardRef<
               ) : null}
               {label}
             </chakra.span>
+
             <ToggleChevronWrapper
               layerStyle="focusRing.default"
               aria-label={onlyCaretToggle ? 'Toggle section' : undefined}
               onClick={onToggle}
               display="flex"
               outline="none"
+              onlyCaretToggle={onlyCaretToggle}
             >
               <ToggleChevron
                 reduceMotion={reduceMotion}

--- a/react/src/Sidebar/SidebarList.tsx
+++ b/react/src/Sidebar/SidebarList.tsx
@@ -1,9 +1,10 @@
-import { type PropsWithChildren, useCallback, useMemo } from 'react'
+import { FC, type PropsWithChildren, useCallback, useMemo } from 'react'
 import {
   Box,
   chakra,
   Collapse,
   forwardRef,
+  HTMLChakraProps,
   Icon,
   useDisclosure,
   type UseDisclosureReturn,
@@ -52,6 +53,23 @@ export interface SidebarListProps extends BaseSidebarItemProps {
   isActive?: boolean | (() => boolean)
   /** Callback invoked when section is clicked */
   onClick?: () => void
+}
+
+type SectionWrapperProps = HTMLChakraProps<'button'> &
+  HTMLChakraProps<'div'> & { onlyCaretToggle: boolean }
+
+const SectionWrapper: FC<PropsWithChildren & SectionWrapperProps> = ({
+  children,
+  onlyCaretToggle,
+  ...props
+}) => {
+  if (onlyCaretToggle) return <chakra.div {...props}>{children}</chakra.div>
+
+  return (
+    <chakra.button {...props} type="button">
+      {children}
+    </chakra.button>
+  )
 }
 
 export const SidebarList = forwardRef<
@@ -104,11 +122,6 @@ export const SidebarList = forwardRef<
       return merge({}, mergedStyles, { cursor: 'pointer' })
     }, [onlyCaretToggle, styles.item, styles.parent])
 
-    const SectionWrapper = useMemo(() => {
-      if (onlyCaretToggle) return chakra.div
-      return chakra.button
-    }, [onlyCaretToggle])
-
     const ToggleChevronWrapper = useMemo(() => {
       if (onlyCaretToggle) return chakra.button
       return chakra.div
@@ -122,6 +135,7 @@ export const SidebarList = forwardRef<
             data-expanded={dataAttr(isOpen)}
             data-active={dataAttr(dataActive)}
             onClick={handleExpandSection}
+            onlyCaretToggle={onlyCaretToggle}
           >
             <chakra.span flex={1} __css={styles.label}>
               {icon ? (

--- a/react/src/Sidebar/SidebarList.tsx
+++ b/react/src/Sidebar/SidebarList.tsx
@@ -66,7 +66,7 @@ const SectionWrapper: FC<PropsWithChildren & SectionWrapperProps> = ({
   if (onlyCaretToggle) return <chakra.div {...props}>{children}</chakra.div>
 
   return (
-    <chakra.button {...props} type="button">
+    <chakra.button type="button" {...props}>
       {children}
     </chakra.button>
   )
@@ -78,7 +78,7 @@ const ToggleChevronWrapper: FC<PropsWithChildren & SectionWrapperProps> = ({
 }) => {
   if (onlyCaretToggle)
     return (
-      <chakra.button {...props} type="button">
+      <chakra.button type="button" {...props}>
         {children}
       </chakra.button>
     )


### PR DESCRIPTION
Closes #517

## Solution
- Refactor `SectionWrapper` to not return chakra factory, but be a conditional wrapper that forwards props over to the child chakra div or button. This is so that the `type=button` prop can be passed to the button element.