### PR TITLE
fix: remove `pattern` prop on datepickers, add `experimental_forceIosNumberKeyboard` prop to trigger it instead

### DIFF
--- a/react/src/DatePicker/DatePickerContext.tsx
+++ b/react/src/DatePicker/DatePickerContext.tsx
@@ -56,6 +56,7 @@ interface DatePickerContextReturn {
     | 'showOutsideDays'
     | 'showTodayButton'
   >
+  inputPattern?: string
 }
 
 const DatePickerContext = createContext<DatePickerContextReturn | null>(null)
@@ -103,6 +104,7 @@ const useProvideDatePicker = ({
   refocusOnClose = true,
   ssr,
   size,
+  experimental_forceIosNumberKeyboard,
   ...props
 }: DatePickerProps): DatePickerContextReturn => {
   const initialFocusRef = useRef<HTMLInputElement>(null)
@@ -111,6 +113,12 @@ const useProvideDatePicker = ({
   const calendarProps = pickCalendarProps(props)
 
   const isMobile = useIsMobile({ ssr })
+
+  const inputPattern = useMemo(() => {
+    if (experimental_forceIosNumberKeyboard) {
+      return '[0-9]*'
+    }
+  }, [experimental_forceIosNumberKeyboard])
 
   const disclosureProps = useDisclosure({
     onClose: () => {
@@ -257,5 +265,6 @@ const useProvideDatePicker = ({
     size,
     disclosureProps,
     calendarProps,
+    inputPattern,
   }
 }

--- a/react/src/DatePicker/components/DatePickerInput.tsx
+++ b/react/src/DatePicker/components/DatePickerInput.tsx
@@ -55,8 +55,7 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
         {hasMounted ? (
           <Input
             size={size}
-            inputMode="numeric" // Nudge Android mobile keyboard to be numeric
-            pattern="\d*" // Nudge numeric keyboard on iOS Safari.
+            inputMode="numeric" // Nudge Android mobile keyboard to be numeric.
             as={ReactInputMask}
             mask="99/99/9999"
             value={internalInputValue}
@@ -70,12 +69,7 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
             isReadOnly={fcProps.isReadOnly || !allowManualInput}
           />
         ) : (
-          <Input
-            pattern="\d*"
-            size={size}
-            inputMode="numeric"
-            placeholder={placeholder}
-          />
+          <Input size={size} inputMode="numeric" placeholder={placeholder} />
         )}
         <InputRightAddon p={0} border="none">
           <CalendarButton />

--- a/react/src/DatePicker/components/DatePickerInput.tsx
+++ b/react/src/DatePicker/components/DatePickerInput.tsx
@@ -27,6 +27,7 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
     inputRef,
     internalValue,
     size,
+    inputPattern,
   } = useDatePicker()
 
   const mergedInputRef = useMergeRefs(inputRef, ref)
@@ -55,6 +56,7 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
         {hasMounted ? (
           <Input
             size={size}
+            pattern={inputPattern}
             inputMode="numeric" // Nudge Android mobile keyboard to be numeric.
             as={ReactInputMask}
             mask="99/99/9999"
@@ -69,7 +71,12 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
             isReadOnly={fcProps.isReadOnly || !allowManualInput}
           />
         ) : (
-          <Input size={size} inputMode="numeric" placeholder={placeholder} />
+          <Input
+            size={size}
+            inputMode="numeric"
+            placeholder={placeholder}
+            pattern={inputPattern}
+          />
         )}
         <InputRightAddon p={0} border="none">
           <CalendarButton />

--- a/react/src/DatePicker/types.ts
+++ b/react/src/DatePicker/types.ts
@@ -33,11 +33,11 @@ export interface DatePickerBaseProps
   /**
    * Whether to force the number keyboard on iOS.
    *
-   * This will set the inputmode to `numeric` and pattern to `[0-9]*` on the input, which
+   * This will set the `pattern` prop on the input to `[0-9]*`, which
    * will force the number keyboard to show on iOS for a better user experience.
    *
    * ⚠️ This will break native form input validation if set, since the value of the input
-   * will always be `"DD/MM/YYYY"`, which does not conform to the input.
+   * will always be `"DD/MM/YYYY"`, which does not conform to the pattern.
    * To prevent native form validation, set `noValidate` on the parent `form` component.
    */
   experimental_forceIosNumberKeyboard?: boolean

--- a/react/src/DatePicker/types.ts
+++ b/react/src/DatePicker/types.ts
@@ -29,6 +29,18 @@ export interface DatePickerBaseProps
    * @defaultValue `true`
    */
   closeCalendarOnChange?: boolean
+
+  /**
+   * Whether to force the number keyboard on iOS.
+   *
+   * This will set the inputmode to `numeric` and pattern to `[0-9]*` on the input, which
+   * will force the number keyboard to show on iOS for a better user experience.
+   *
+   * ⚠️ This will break native form input validation if set, since the value of the input
+   * will always be `"DD/MM/YYYY"`, which does not conform to the input.
+   * To prevent native form validation, set `noValidate` on the parent `form` component.
+   */
+  experimental_forceIosNumberKeyboard?: boolean
   /**
    * Whether to refocus date picker when calendar is closed.
    * @defaultValue `true`

--- a/react/src/DateRangePicker/DateRangePickerContext.tsx
+++ b/react/src/DateRangePicker/DateRangePickerContext.tsx
@@ -61,6 +61,7 @@ interface DateRangePickerContextReturn {
     | 'defaultFocusedDate'
     | 'showTodayButton'
   >
+  inputPattern?: string
 }
 
 const DateRangePickerContext =
@@ -109,6 +110,7 @@ const useProvideDateRangePicker = ({
   refocusOnClose = true,
   size,
   ssr,
+  experimental_forceIosNumberKeyboard,
   ...props
 }: DateRangePickerProps): DateRangePickerContextReturn => {
   const initialFocusRef = useRef<HTMLInputElement>(null)
@@ -118,6 +120,12 @@ const useProvideDateRangePicker = ({
   const calendarProps = pickCalendarProps(props)
 
   const isMobile = useIsMobile({ ssr })
+
+  const inputPattern = useMemo(() => {
+    if (experimental_forceIosNumberKeyboard) {
+      return '[0-9]*'
+    }
+  }, [experimental_forceIosNumberKeyboard])
 
   const disclosureProps = useDisclosure({
     onClose: () => {
@@ -343,5 +351,6 @@ const useProvideDateRangePicker = ({
     disclosureProps,
     labelSeparator,
     calendarProps,
+    inputPattern,
   }
 }

--- a/react/src/DateRangePicker/components/DateRangePickerInput.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerInput.tsx
@@ -75,7 +75,6 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
             variant="unstyled"
             aria-label="Start date of range"
             inputMode="numeric" // Nudge Android mobile keyboard to be numeric
-            pattern="\d*" // Nudge numeric keyboard on iOS Safari.
             sx={styles.field}
             width="6rem"
             as={ReactInputMask}
@@ -95,7 +94,6 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
             size={size}
             variant="unstyled"
             inputMode="numeric"
-            pattern="\d*"
             placeholder={placeholder}
             sx={styles.field}
             width="6rem"
@@ -108,7 +106,6 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
             size={size}
             aria-label="Start date of range"
             inputMode="numeric" // Nudge Android mobile keyboard to be numeric
-            pattern="\d*" // Nudge numeric keyboard on iOS Safari.
             sx={styles.field}
             width="6rem"
             as={ReactInputMask}
@@ -128,7 +125,6 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
             size={size}
             variant="unstyled"
             inputMode="numeric"
-            pattern="\d*"
             placeholder={placeholder}
             sx={styles.field}
             width="6rem"

--- a/react/src/DateRangePicker/components/DateRangePickerInput.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerInput.tsx
@@ -31,6 +31,7 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
     handleEndDateChange,
     internalValue: [startDate, endDate],
     size,
+    inputPattern,
   } = useDateRangePicker()
 
   const mergedStartInputRef = useMergeRefs(startInputRef, ref)
@@ -75,6 +76,7 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
             variant="unstyled"
             aria-label="Start date of range"
             inputMode="numeric" // Nudge Android mobile keyboard to be numeric
+            pattern={inputPattern}
             sx={styles.field}
             width="6rem"
             as={ReactInputMask}
@@ -92,6 +94,7 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
         ) : (
           <Input
             size={size}
+            pattern={inputPattern}
             variant="unstyled"
             inputMode="numeric"
             placeholder={placeholder}
@@ -104,6 +107,7 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
           <Input
             variant="unstyled"
             size={size}
+            pattern={inputPattern}
             aria-label="Start date of range"
             inputMode="numeric" // Nudge Android mobile keyboard to be numeric
             sx={styles.field}
@@ -123,6 +127,7 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
         ) : (
           <Input
             size={size}
+            pattern={inputPattern}
             variant="unstyled"
             inputMode="numeric"
             placeholder={placeholder}


### PR DESCRIPTION
that was causing some form validation to prevent submission, since the underlying value does not fit the pattern.
to allow users to still have the preference (since it does improve the UX greatly), add a new `experimental_forceIosNumberKeyboard` prop that does the same thing instead. 

docs:
```ts
 /**
   * Whether to force the number keyboard on iOS.
   *
   * This will set the inputmode to `numeric` and pattern to `[0-9]*` on the input, which
   * will force the number keyboard to show on iOS for a better user experience.
   *
   * ⚠️ This will break native form input validation if set, since the value of the input
   * will always be `"DD/MM/YYYY"`, which does not conform to the input.
   * To prevent native form validation, set `noValidate` on the parent `form` component.
   */
```