### PR TITLE
feat: allow custom input element override for DatePicker

### DIFF
--- a/react/src/DatePicker/DatePicker.stories.tsx
+++ b/react/src/DatePicker/DatePicker.stories.tsx
@@ -1,9 +1,11 @@
+import { Button, chakra, forwardRef, useMergeRefs } from '@chakra-ui/react'
 import { Meta, StoryFn } from '@storybook/react'
 import { userEvent, within } from '@storybook/testing-library'
 
 import { getMobileViewParameters, mockDateDecorator } from '~/utils/storybook'
 
 import { DatePicker, DatePickerProps } from './DatePicker'
+import { useDatePicker } from './DatePickerContext'
 
 export default {
   title: 'Components/DatePicker',
@@ -65,3 +67,21 @@ SizeXs.args = {
 
 export const Mobile = Template.bind({})
 Mobile.parameters = getMobileViewParameters()
+
+const CustomInputButton = forwardRef<object, 'button'>((_props, ref) => {
+  const { inputRef, innerRef, disclosureProps } = useDatePicker()
+
+  const refs = useMergeRefs(inputRef, innerRef, ref)
+
+  const { onOpen } = disclosureProps
+  return (
+    <Button ref={refs} onClick={onOpen}>
+      please look at source code to see how to use custom elements
+    </Button>
+  )
+})
+
+export const CustomInput = Template.bind({})
+CustomInput.args = {
+  inputElement: <CustomInputButton />,
+}

--- a/react/src/DatePicker/DatePicker.tsx
+++ b/react/src/DatePicker/DatePicker.tsx
@@ -22,8 +22,8 @@ export interface DatePickerProps extends DatePickerBaseProps, CalendarProps {
 
 export const DatePicker = forwardRef<DatePickerProps, 'input'>((props, ref) => {
   return (
-    <DatePickerProvider {...props}>
-      <DatePickerWrapper ref={ref}>
+    <DatePickerProvider {...props} innerRef={ref}>
+      <DatePickerWrapper>
         <DatePickerContent>
           <DatePickerCalendar />
         </DatePickerContent>

--- a/react/src/DatePicker/DatePickerContext.tsx
+++ b/react/src/DatePicker/DatePickerContext.tsx
@@ -47,6 +47,8 @@ interface DatePickerContextReturn {
   colorScheme?: ThemingProps<'DatePicker'>['colorScheme']
   size?: ThemingProps<'DatePicker'>['size']
   disclosureProps: UseDisclosureReturn
+  inputElement?: React.ReactNode
+  innerRef?: React.Ref<HTMLElement>
   calendarProps: Pick<
     CalendarProps,
     | 'isCalendarFixedHeight'
@@ -62,10 +64,14 @@ interface DatePickerContextReturn {
 
 const DatePickerContext = createContext<DatePickerContextReturn | null>(null)
 
+interface DatePickerProviderProps extends DatePickerProps {
+  innerRef?: React.Ref<HTMLElement>
+}
+
 export const DatePickerProvider = ({
   children,
   ...props
-}: PropsWithChildren<DatePickerProps>) => {
+}: PropsWithChildren<DatePickerProviderProps>) => {
   const value = useProvideDatePicker(props)
   return (
     <DatePickerContext.Provider value={value}>
@@ -106,8 +112,10 @@ const useProvideDatePicker = ({
   ssr,
   size,
   experimental_forceIosNumberKeyboard,
+  inputElement,
+  innerRef,
   ...props
-}: DatePickerProps): DatePickerContextReturn => {
+}: DatePickerProviderProps): DatePickerContextReturn => {
   const initialFocusRef = useRef<HTMLInputElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -269,5 +277,7 @@ const useProvideDatePicker = ({
     disclosureProps,
     calendarProps,
     inputPattern,
+    inputElement,
+    innerRef,
   }
 }

--- a/react/src/DatePicker/components/DatePickerInput.tsx
+++ b/react/src/DatePicker/components/DatePickerInput.tsx
@@ -28,9 +28,10 @@ export const DatePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
     internalValue,
     size,
     inputPattern,
+    innerRef,
   } = useDatePicker()
 
-  const mergedInputRef = useMergeRefs(inputRef, ref)
+  const mergedInputRef = useMergeRefs(inputRef, innerRef, ref)
 
   const selectedDateAriaLiveText = useMemo(() => {
     if (!internalValue) {

--- a/react/src/DatePicker/components/DatePickerWrapper.tsx
+++ b/react/src/DatePicker/components/DatePickerWrapper.tsx
@@ -1,46 +1,45 @@
-import { Flex, forwardRef, Popover, PopoverAnchor } from '@chakra-ui/react'
+import { PropsWithChildren, useMemo } from 'react'
+import { Flex, Popover, PopoverAnchor } from '@chakra-ui/react'
 
 import { useDatePicker } from '../DatePickerContext'
 
 import { DatePickerInput } from './DatePickerInput'
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const DatePickerWrapper = forwardRef<{}, 'input'>(
-  ({ children }, ref) => {
-    const {
-      disclosureProps,
-      initialFocusRef,
-      closeCalendarOnChange,
-      isMobile,
-    } = useDatePicker()
+export const DatePickerWrapper = ({ children }: PropsWithChildren) => {
+  const {
+    disclosureProps,
+    initialFocusRef,
+    closeCalendarOnChange,
+    isMobile,
+    inputElement,
+  } = useDatePicker()
 
-    if (isMobile) {
-      return (
-        <Flex>
-          <DatePickerInput ref={ref} />
-          {children}
-        </Flex>
-      )
-    }
+  const inputToRender = useMemo(() => {
+    return inputElement ?? <DatePickerInput />
+  }, [inputElement])
 
+  if (isMobile) {
     return (
       <Flex>
-        <Popover
-          placement="bottom-start"
-          isLazy
-          initialFocusRef={initialFocusRef}
-          closeOnBlur={closeCalendarOnChange}
-          returnFocusOnClose={false}
-          {...disclosureProps}
-        >
-          <PopoverAnchor>
-            <DatePickerInput ref={ref} />
-          </PopoverAnchor>
-          {children}
-        </Popover>
+        <DatePickerInput />
+        {children}
       </Flex>
     )
-  },
-)
+  }
 
-DatePickerWrapper.displayName = 'DatePickerWrapper'
+  return (
+    <Flex>
+      <Popover
+        placement="bottom-start"
+        isLazy
+        initialFocusRef={initialFocusRef}
+        closeOnBlur={closeCalendarOnChange}
+        returnFocusOnClose={false}
+        {...disclosureProps}
+      >
+        <PopoverAnchor>{inputToRender}</PopoverAnchor>
+        {children}
+      </Popover>
+    </Flex>
+  )
+}

--- a/react/src/DatePicker/index.ts
+++ b/react/src/DatePicker/index.ts
@@ -1,2 +1,3 @@
 export * from './DatePicker'
+export { useDatePicker } from './DatePickerContext'
 export type { DatePickerBaseProps } from './types'

--- a/react/src/DatePicker/types.ts
+++ b/react/src/DatePicker/types.ts
@@ -48,4 +48,5 @@ export interface DatePickerBaseProps
   refocusOnClose?: boolean
   /** date-fns's Locale of the date to be applied if provided. */
   locale?: Locale
+  inputElement?: React.ReactElement
 }


### PR DESCRIPTION
allows for users to trigger the calendar without using the default input

A little convoluted to use, but allows the flexibility if needed!