### PR TITLE
fix: allow correct toggling of datepicker/daterangepicker with calendar button

### DIFF
--- a/react/src/DatePicker/components/CalendarButton.tsx
+++ b/react/src/DatePicker/components/CalendarButton.tsx
@@ -18,6 +18,7 @@ export const CalendarButton = (): JSX.Element => {
     <IconButton
       data-group
       size={size}
+      sx={styles.calendarButton}
       aria-invalid={isInvalid}
       onClick={onOpen}
       variant="inputAttached"

--- a/react/src/DatePicker/components/DatePickerOverlay.tsx
+++ b/react/src/DatePicker/components/DatePickerOverlay.tsx
@@ -1,0 +1,22 @@
+import { Box } from '@chakra-ui/react'
+
+import { useDatePicker } from '../DatePickerContext'
+
+export const DatePickerOverlay = () => {
+  const {
+    disclosureProps: { isOpen },
+  } = useDatePicker()
+
+  return (
+    <Box
+      position="fixed"
+      left="0px"
+      top="0px"
+      width="100vw"
+      height="$100vh"
+      display={isOpen ? 'block' : 'none'}
+      aria-hidden
+      bg="transparent"
+    />
+  )
+}

--- a/react/src/DatePicker/components/DatePickerWrapper.tsx
+++ b/react/src/DatePicker/components/DatePickerWrapper.tsx
@@ -1,9 +1,28 @@
 import { PropsWithChildren, useMemo } from 'react'
-import { Flex, Popover, PopoverAnchor } from '@chakra-ui/react'
+import { Box, Flex, Popover, PopoverAnchor } from '@chakra-ui/react'
 
 import { useDatePicker } from '../DatePickerContext'
 
 import { DatePickerInput } from './DatePickerInput'
+
+const DatePickerOverlay = () => {
+  const {
+    disclosureProps: { isOpen },
+  } = useDatePicker()
+
+  return (
+    <Box
+      position="fixed"
+      left="0px"
+      top="0px"
+      width="100vw"
+      height="$100vh"
+      display={isOpen ? 'block' : 'none'}
+      aria-hidden
+      bg="transparent"
+    />
+  )
+}
 
 export const DatePickerWrapper = ({ children }: PropsWithChildren) => {
   const {
@@ -40,6 +59,7 @@ export const DatePickerWrapper = ({ children }: PropsWithChildren) => {
         <PopoverAnchor>{inputToRender}</PopoverAnchor>
         {children}
       </Popover>
+      <DatePickerOverlay />
     </Flex>
   )
 }

--- a/react/src/DatePicker/components/DatePickerWrapper.tsx
+++ b/react/src/DatePicker/components/DatePickerWrapper.tsx
@@ -1,28 +1,10 @@
 import { PropsWithChildren, useMemo } from 'react'
-import { Box, Flex, Popover, PopoverAnchor } from '@chakra-ui/react'
+import { Flex, Popover, PopoverAnchor } from '@chakra-ui/react'
 
 import { useDatePicker } from '../DatePickerContext'
 
 import { DatePickerInput } from './DatePickerInput'
-
-const DatePickerOverlay = () => {
-  const {
-    disclosureProps: { isOpen },
-  } = useDatePicker()
-
-  return (
-    <Box
-      position="fixed"
-      left="0px"
-      top="0px"
-      width="100vw"
-      height="$100vh"
-      display={isOpen ? 'block' : 'none'}
-      aria-hidden
-      bg="transparent"
-    />
-  )
-}
+import { DatePickerOverlay } from './DatePickerOverlay'
 
 export const DatePickerWrapper = ({ children }: PropsWithChildren) => {
   const {

--- a/react/src/DateRangePicker/components/CalendarButton.tsx
+++ b/react/src/DateRangePicker/components/CalendarButton.tsx
@@ -21,6 +21,7 @@ export const CalendarButton = (): JSX.Element => {
       aria-invalid={isInvalid}
       onClick={onOpen}
       variant="inputAttached"
+      sx={styles.calendarButton}
       aria-label={calendarButtonAria}
       icon={<Icon as={BxCalendar} sx={styles.inputButton} />}
       isActive={isOpen}

--- a/react/src/DateRangePicker/components/DateRangePickerOverlay.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerOverlay.tsx
@@ -1,0 +1,23 @@
+import { Box } from '@chakra-ui/react'
+
+import { useDateRangePicker } from '../DateRangePickerContext'
+
+export const DateRangePickerOverlay = () => {
+  const {
+    disclosureProps: { isOpen },
+  } = useDateRangePicker()
+
+  return (
+    <Box
+      position="fixed"
+      left="0px"
+      top="0px"
+      width="100vw"
+      height="$100vh"
+      display={isOpen ? 'block' : 'none'}
+      aria-hidden
+      bg="transparent"
+      zIndex={1}
+    />
+  )
+}

--- a/react/src/DateRangePicker/components/DateRangePickerWrapper.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerWrapper.tsx
@@ -3,6 +3,7 @@ import { Flex, forwardRef, Popover, PopoverAnchor } from '@chakra-ui/react'
 import { useDateRangePicker } from '../DateRangePickerContext'
 
 import { DateRangePickerInput } from './DateRangePickerInput'
+import { DateRangePickerOverlay } from './DateRangePickerOverlay'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const DateRangePickerWrapper = forwardRef<{}, 'input'>(
@@ -58,6 +59,7 @@ export const DateRangePickerWrapper = forwardRef<{}, 'input'>(
           </PopoverAnchor>
           {children}
         </Popover>
+        <DateRangePickerOverlay />
       </Flex>
     )
   },

--- a/react/src/theme/components/DatePicker.ts
+++ b/react/src/theme/components/DatePicker.ts
@@ -7,6 +7,7 @@ export const datepickerAnatomy = anatomy('datepicker').parts(
   'header',
   'inputButton',
   'container',
+  'calendarButton',
 )
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(datepickerAnatomy.keys)
@@ -33,6 +34,17 @@ export const DatePicker = defineMultiStyleConfig({
   baseStyle: {
     container: {
       bg: 'utility.ui',
+    },
+    calendarButton: {
+      _active: {
+        zIndex: '1',
+        borderColor: 'utility.focus-default',
+        bg: 'interaction.muted.main.hover',
+        boxShadow: 'none',
+        _disabled: {
+          bg: 'interaction.support.disabled',
+        },
+      },
     },
     header: {
       h: '3.5rem',


### PR DESCRIPTION
Ancient bug that has been in design system since its inception!

previously, when clicking on the calendar button, the calendar popover will open. If the button is clicked again, the open popover will be  blurred, but the button will set the open state to "open" again (since the button triggers the open state). However, since the popover was in its closing animation, the popover will not open again. This results in a state desynchronisation between the state and the render, and the date picker cannot be opened again.

The easiest fix is to add a full screen overlay behind the popover when it is open, so any click outside will blur the calendar before allowing any other elements to be clicked.