### PR TITLE
fix: use dvh ($100vh) in full screen modals

### DIFF
--- a/react/src/theme/components/Modal.ts
+++ b/react/src/theme/components/Modal.ts
@@ -29,7 +29,7 @@ const baseStyle = definePartsStyle((props) => ({
 
 const fullDialogStyle: SystemStyleObject = {
   maxW: '100vw',
-  minH: '100vh',
+  minH: '$100vh',
   my: 0,
   borderRadius: 0,
 }


### PR DESCRIPTION
mobile phones have bottom nav bars nowadays. If `100vh` was used, buttons that are sticky on the bottom will be hidden below the nav bar. Use `100dvh` instead (which is allowed by ChakraUI's shorthand `$100vh`, which only uses dvh if the media query is supported)
