### PR TITLE
feat: allow users to change focusRing layerStyle in component theme

### DIFF
--- a/react/src/Toolbar/utils/useToolbarButtonProps.ts
+++ b/react/src/Toolbar/utils/useToolbarButtonProps.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
-import { useBreakpointValue } from '@chakra-ui/react'
+import { useBreakpointValue, useTheme } from '@chakra-ui/react'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { ButtonProps } from '~/Button'
 import { layerStyles } from '~/theme/layerStyles'
@@ -8,6 +9,13 @@ import { useToolbarContext } from '../ToolbarContext'
 
 export const useToolbarButtonProps = (): ButtonProps => {
   const { colorScheme, size } = useToolbarContext()
+  const theme = useTheme()
+
+  const inverseFocusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.inverse._focusVisible',
+    layerStyles.focusRing.inverse._focusVisible,
+  )
 
   const toolbarBreakpointSize = useBreakpointValue(
     typeof size === 'string' ? { base: size } : size,
@@ -28,12 +36,12 @@ export const useToolbarButtonProps = (): ButtonProps => {
       case 'sub':
         return {
           colorScheme: 'inverse',
-          _focusVisible: layerStyles.focusRing.inverse._focusVisible,
+          _focusVisible: inverseFocusRingStyle,
         }
       default:
         return { colorScheme }
     }
-  }, [colorScheme])
+  }, [colorScheme, inverseFocusRingStyle])
 
   return {
     ...toolbarButtonStyleProps,

--- a/react/src/theme/components/AvatarMenu.ts
+++ b/react/src/theme/components/AvatarMenu.ts
@@ -1,5 +1,6 @@
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 import { anatomy, StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 
@@ -79,29 +80,37 @@ const variants = {
   solid: variantSolid,
 }
 
-const baseStyle = definePartsStyle({
-  button: {
-    px: '0',
-    bg: 'transparent',
-    color: 'base.content.strong',
-    _hover: {
+const baseStyle = definePartsStyle(({ theme }) => {
+  const focusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
+
+  return {
+    button: {
+      px: '0',
       bg: 'transparent',
+      color: 'base.content.strong',
+      _hover: {
+        bg: 'transparent',
+      },
+      _active: {
+        bg: 'transparent',
+      },
+      _focusVisible: {
+        outline: 'none',
+      },
     },
-    _active: {
-      bg: 'transparent',
+    avatar: {
+      transitionProperty: 'common',
+      transitionDuration: 'normal',
+      _groupFocus: focusRingStyle,
+      _groupActive: {
+        ...focusRingStyle,
+      },
     },
-    _focusVisible: {
-      outline: 'none',
-    },
-  },
-  avatar: {
-    transitionProperty: 'common',
-    transitionDuration: 'normal',
-    _groupFocus: layerStyles.focusRing.default._focusVisible,
-    _groupActive: {
-      ...layerStyles.focusRing.default._focusVisible,
-    },
-  },
+  }
 })
 
 const sizes = {

--- a/react/src/theme/components/Banner.ts
+++ b/react/src/theme/components/Banner.ts
@@ -1,5 +1,6 @@
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 import { anatomy } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 
@@ -57,58 +58,81 @@ const sizes = {
   }),
 }
 
-const variantInfo = definePartsStyle({
-  banner: {
-    color: 'base.content.inverse',
-    bg: 'utility.feedback.info',
-  },
-  link: {
-    color: 'base.content.inverse',
-    _hover: {
+const variantInfo = definePartsStyle(({ theme }) => {
+  const focusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.inverse',
+    layerStyles.focusRing.inverse,
+  )
+
+  return {
+    banner: {
       color: 'base.content.inverse',
+      bg: 'utility.feedback.info',
     },
-    ...layerStyles.focusRing.inverse,
-  },
-  close: {
-    color: 'base.content.inverse',
-    ...layerStyles.focusRing.inverse,
-  },
+    link: {
+      color: 'base.content.inverse',
+      _hover: {
+        color: 'base.content.inverse',
+      },
+      ...focusRingStyle,
+    },
+    close: {
+      color: 'base.content.inverse',
+      ...focusRingStyle,
+    },
+  }
 })
 
-const variantWarn = definePartsStyle({
-  banner: {
-    color: 'base.content.strong',
-    bg: 'utility.feedback.warning',
-  },
-  link: {
-    color: 'base.content.strong',
-    _hover: {
+const variantWarn = definePartsStyle(({ theme }) => {
+  const focusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.default',
+    layerStyles.focusRing.default,
+  )
+  return {
+    banner: {
       color: 'base.content.strong',
+      bg: 'utility.feedback.warning',
     },
-    ...layerStyles.focusRing.default,
-  },
-  close: {
-    color: 'base.content.strong',
-    ...layerStyles.focusRing.default,
-  },
+    link: {
+      color: 'base.content.strong',
+      _hover: {
+        color: 'base.content.strong',
+      },
+      ...focusRingStyle,
+    },
+    close: {
+      color: 'base.content.strong',
+      ...focusRingStyle,
+    },
+  }
 })
 
-const variantError = definePartsStyle({
-  banner: {
-    color: 'base.content.inverse',
-    bg: 'utility.feedback.critical',
-  },
-  link: {
-    color: 'base.content.inverse',
-    _hover: {
+const variantError = definePartsStyle(({ theme }) => {
+  const focusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.inverse',
+    layerStyles.focusRing.inverse,
+  )
+
+  return {
+    banner: {
       color: 'base.content.inverse',
+      bg: 'utility.feedback.critical',
     },
-    ...layerStyles.focusRing.inverse,
-  },
-  close: {
-    color: 'base.content.inverse',
-    ...layerStyles.focusRing.inverse,
-  },
+    link: {
+      color: 'base.content.inverse',
+      _hover: {
+        color: 'base.content.inverse',
+      },
+      ...focusRingStyle,
+    },
+    close: {
+      color: 'base.content.inverse',
+      ...focusRingStyle,
+    },
+  }
 })
 
 const variants = {

--- a/react/src/theme/components/Breadcrumb.ts
+++ b/react/src/theme/components/Breadcrumb.ts
@@ -4,6 +4,7 @@ import {
   cssVar,
   defineStyle,
 } from '@chakra-ui/styled-system'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 import { textStyles } from '../textStyles'
@@ -17,6 +18,11 @@ const $decor = cssVar('breadcrumb-link-decor')
 
 const baseStyleLink = defineStyle((props) => {
   const linkStyle = Link.baseStyle?.(props)
+  const focusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
 
   return {
     transitionProperty: 'common',
@@ -35,7 +41,7 @@ const baseStyleLink = defineStyle((props) => {
       },
       outlineOffset: '0.25rem',
       _focusVisible: {
-        ...layerStyles.focusRing.default._focusVisible,
+        ...focusRingStyle,
         outlineOffset: '0.25rem',
       },
     },

--- a/react/src/theme/components/Button.ts
+++ b/react/src/theme/components/Button.ts
@@ -1,5 +1,6 @@
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 import { getColor, StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 import { merge } from 'lodash'
 
 import { layerStyles } from '../layerStyles'
@@ -266,22 +267,29 @@ const variants = {
   inputAttached: variantInputAttached,
 }
 
-const baseStyle = defineStyle({
-  ...textStyles['subhead-1'],
-  whiteSpace: 'pre-wrap',
-  borderRadius: 'base',
-  border: '1px solid',
-  flexShrink: 0,
-  // -1px for border
-  px: '15px',
-  py: '9px',
-  _disabled: {
-    bg: 'interaction.support.disabled',
-    borderColor: 'interaction.support.disabled',
-    opacity: 1,
-    color: 'interaction.support.disabled-content',
-  },
-  ...layerStyles.focusRing.default,
+const baseStyle = defineStyle(({ theme }) => {
+  const focusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.default',
+    layerStyles.focusRing.default,
+  )
+  return {
+    ...textStyles['subhead-1'],
+    whiteSpace: 'pre-wrap',
+    borderRadius: 'base',
+    border: '1px solid',
+    flexShrink: 0,
+    // -1px for border
+    px: '15px',
+    py: '9px',
+    _disabled: {
+      bg: 'interaction.support.disabled',
+      borderColor: 'interaction.support.disabled',
+      opacity: 1,
+      color: 'interaction.support.disabled-content',
+    },
+    ...focusRingStyle,
+  }
 })
 
 const sizes = {

--- a/react/src/theme/components/Calendar.ts
+++ b/react/src/theme/components/Calendar.ts
@@ -1,5 +1,6 @@
 import { createMultiStyleConfigHelpers, defineStyle } from '@chakra-ui/react'
 import { anatomy, StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 import { textStyles } from '../textStyles'
@@ -62,6 +63,12 @@ const baseDayOfMonthStyles = defineStyle((props) => {
   const { color, activeBg, borderColor, activeColor, hoverBg, selectedBg } =
     getDayOfMonthColors(props)
 
+  const focusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
+
   return {
     display: 'inline-block',
     borderRadius: '50%',
@@ -79,9 +86,7 @@ const baseDayOfMonthStyles = defineStyle((props) => {
     _selected: {
       bg: selectedBg,
     },
-    _focus: {
-      ...layerStyles.focusRing.default._focusVisible,
-    },
+    _focus: focusRingStyle,
     _disabled: {
       _hover: {
         bg: hoverBg,
@@ -199,54 +204,60 @@ const monthYearDisplayStyles = defineStyle({
   py: '0.25rem',
 })
 
-const baseStyle = definePartsStyle((props) => ({
-  container: {
-    display: 'inline-block',
-  },
-  monthYearSelectorContainer: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  monthYearSelect: {
-    ...monthYearDisplayStyles,
-    borderColor: 'transparent',
-    cursor: 'pointer',
-    _hover: {
+const baseStyle = definePartsStyle((props) => {
+  const focusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
+
+  return {
+    container: {
+      display: 'inline-block',
+    },
+    monthYearSelectorContainer: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+    monthYearSelect: {
+      ...monthYearDisplayStyles,
       borderColor: 'transparent',
+      cursor: 'pointer',
+      _hover: {
+        borderColor: 'transparent',
+      },
+      _focusVisible: focusRingStyle,
     },
-    _focusVisible: {
-      ...layerStyles.focusRing.default._focusVisible,
+    monthYearDisplay: monthYearDisplayStyles,
+    monthYearDropdownContainer: {
+      display: 'flex',
+      justifyContent: 'flex-start',
     },
-  },
-  monthYearDisplay: monthYearDisplayStyles,
-  monthYearDropdownContainer: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-  },
-  monthArrowContainer: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-  },
-  calendarContainer: {
-    display: {
-      base: 'block',
-      md: 'flex',
+    monthArrowContainer: {
+      display: 'flex',
+      justifyContent: 'flex-end',
     },
-  },
-  monthGrid: {
-    w: '100%',
-    justifyItems: 'left',
-  },
-  dayNamesContainer: {
-    color: 'base.content.default',
-  },
-  dayOfMonthContainer: baseDayOfMonthContainerStyles,
-  dayOfMonth: baseDayOfMonthStyles(props),
-  todayLinkContainer: {
-    textAlign: 'center',
-  },
-}))
+    calendarContainer: {
+      display: {
+        base: 'block',
+        md: 'flex',
+      },
+    },
+    monthGrid: {
+      w: '100%',
+      justifyItems: 'left',
+    },
+    dayNamesContainer: {
+      color: 'base.content.default',
+    },
+    dayOfMonthContainer: baseDayOfMonthContainerStyles,
+    dayOfMonth: baseDayOfMonthStyles(props),
+    todayLinkContainer: {
+      textAlign: 'center',
+    },
+  }
+})
 
 export const Calendar = defineMultiStyleConfig({
   baseStyle,

--- a/react/src/theme/components/Checkbox.ts
+++ b/react/src/theme/components/Checkbox.ts
@@ -1,6 +1,7 @@
 import { checkboxAnatomy } from '@chakra-ui/anatomy'
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 import { getColor, mode, StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 import { getContrastColor } from '../utils'
@@ -63,6 +64,12 @@ const baseStyle = definePartsStyle((props) => {
   const { bg, hoverBg, borderColor, iconColor, checkedBg, labelColor } =
     getColorProps(props)
 
+  const focusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
+
   const hoverLabelColor = getContrastColor(
     getColor(props.theme, labelColor),
     getColor(props.theme, hoverBg),
@@ -109,7 +116,7 @@ const baseStyle = definePartsStyle((props) => {
         },
       },
       _focusWithin: {
-        ...layerStyles.focusRing.default._focusVisible,
+        ...focusRingStyle,
         outlineOffset: 0,
       },
     },
@@ -146,7 +153,7 @@ const baseStyle = definePartsStyle((props) => {
         },
       },
       _focusWithin: {
-        ...layerStyles.focusRing.default._focusVisible,
+        ...focusRingStyle,
         outlineOffset: 0,
       },
     },

--- a/react/src/theme/components/CloseButton.ts
+++ b/react/src/theme/components/CloseButton.ts
@@ -1,5 +1,6 @@
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 import { cssVar } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 
@@ -22,11 +23,19 @@ const sizes = {
   }),
 }
 
-const baseStyle = defineStyle({
-  p: 0,
-  _focusVisible: layerStyles.focusRing.default._focusVisible,
-  w: [$size.reference],
-  h: [$size.reference],
+const baseStyle = defineStyle(({ theme }) => {
+  const focusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
+
+  return {
+    p: 0,
+    _focusVisible: focusRingStyle,
+    w: [$size.reference],
+    h: [$size.reference],
+  }
 })
 
 const variantClear = defineStyle((props) => {

--- a/react/src/theme/components/Link.ts
+++ b/react/src/theme/components/Link.ts
@@ -1,5 +1,6 @@
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 import { StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 
@@ -41,6 +42,11 @@ const getLinkColors = ({ colorScheme: c }: StyleFunctionProps) => {
 
 const baseStyle = defineStyle((props) => {
   const { color, hoverColor } = getLinkColors(props)
+  const focusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
 
   return {
     outlineOffset: 0,
@@ -67,7 +73,7 @@ const baseStyle = defineStyle((props) => {
       cursor: 'not-allowed',
     },
     _focusVisible: {
-      ...layerStyles.focusRing.default._focusVisible,
+      ...focusRingStyle,
       outlineOffset: 0,
     },
   }

--- a/react/src/theme/components/Radio.ts
+++ b/react/src/theme/components/Radio.ts
@@ -1,6 +1,7 @@
 import { radioAnatomy } from '@chakra-ui/anatomy'
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 import { StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 
@@ -39,6 +40,12 @@ const getColorProps = ({ colorScheme: c }: StyleFunctionProps) => {
 
 const baseStyle = definePartsStyle((props) => {
   const { bg, hoverBg, borderColor, checkedBg } = getColorProps(props)
+
+  const focusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
 
   return {
     control: {
@@ -86,7 +93,7 @@ const baseStyle = definePartsStyle((props) => {
         },
       },
       _focusWithin: {
-        ...layerStyles.focusRing.default._focusVisible,
+        ...focusRingStyle,
         outlineOffset: 0,
       },
     },
@@ -108,7 +115,7 @@ const baseStyle = definePartsStyle((props) => {
         },
       },
       _focusWithin: {
-        ...layerStyles.focusRing.default._focusVisible,
+        ...focusRingStyle,
         outlineOffset: 0,
       },
     },

--- a/react/src/theme/components/Sidebar.ts
+++ b/react/src/theme/components/Sidebar.ts
@@ -1,5 +1,6 @@
 import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
 import { anatomy } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 
@@ -18,72 +19,80 @@ const parts = anatomy('sidebar').parts(
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
-const baseStyle = definePartsStyle({
-  header: {
-    textStyle: 'subhead-3',
-    px: '1rem',
-    pt: '1rem',
-    pb: '0.75rem',
-  },
-  section: {
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  child: {
-    borderRadius: 0,
-    borderLeftWidth: '1px',
-    borderColor: 'base.divider.medium',
-    _active: {
-      ml: '-1px',
-      borderLeftWidth: '2px',
-      color: 'interaction.main.default',
-      borderColor: 'base.divider.brand',
+const baseStyle = definePartsStyle(({ theme }) => {
+  const focusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
+
+  return {
+    header: {
+      textStyle: 'subhead-3',
+      px: '1rem',
+      pt: '1rem',
+      pb: '0.75rem',
     },
-    _focusVisible: {
+    section: {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    child: {
+      borderRadius: 0,
+      borderLeftWidth: '1px',
+      borderColor: 'base.divider.medium',
+      _active: {
+        ml: '-1px',
+        borderLeftWidth: '2px',
+        color: 'interaction.main.default',
+        borderColor: 'base.divider.brand',
+      },
+      _focusVisible: {
+        borderRadius: 'md',
+      },
+    },
+    parent: {
+      _hover: {
+        bg: 'interaction.muted.main.hover',
+      },
+      _active: {
+        bg: 'interaction.muted.main.active',
+        color: 'interaction.main.default',
+      },
+      _expanded: {
+        bg: 'interaction.muted.main.active',
+        color: 'interaction.main.default',
+      },
       borderRadius: 'md',
     },
-  },
-  parent: {
-    _hover: {
-      bg: 'interaction.muted.main.hover',
+    label: {
+      display: 'flex',
+      alignItems: 'start',
     },
-    _active: {
-      bg: 'interaction.muted.main.active',
-      color: 'interaction.main.default',
+    item: {
+      width: '100%',
+      display: 'flex',
+      alignItems: 'start',
+      listStyleType: 'none',
+      color: 'base.content.default',
+      cursor: 'pointer',
+      _hover: {
+        color: 'interaction.main.default',
+      },
+      _focusVisible: {
+        ...focusRingStyle,
+        outlineOffset: '-2px',
+      },
     },
-    _expanded: {
-      bg: 'interaction.muted.main.active',
-      color: 'interaction.main.default',
+    list: {
+      listStyleType: 'none',
+      display: 'flex',
+      flexDirection: 'column',
     },
-    borderRadius: 'md',
-  },
-  label: {
-    display: 'flex',
-    alignItems: 'start',
-  },
-  item: {
-    width: '100%',
-    display: 'flex',
-    alignItems: 'start',
-    listStyleType: 'none',
-    color: 'base.content.default',
-    cursor: 'pointer',
-    _hover: {
-      color: 'interaction.main.default',
+    nest: {
+      listStyleType: 'none',
     },
-    _focusVisible: {
-      ...layerStyles.focusRing.default._focusVisible,
-      outlineOffset: '-2px',
-    },
-  },
-  list: {
-    listStyleType: 'none',
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  nest: {
-    listStyleType: 'none',
-  },
+  }
 })
 
 const sizes = {

--- a/react/src/theme/components/Switch.ts
+++ b/react/src/theme/components/Switch.ts
@@ -3,6 +3,7 @@ import {
   createMultiStyleConfigHelpers,
   StyleFunctionProps,
 } from '@chakra-ui/react'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 
@@ -25,6 +26,11 @@ const getTrackColor = ({ colorScheme: c }: StyleFunctionProps) => {
 
 const baseStyle = definePartsStyle((props) => {
   const trackColor = getTrackColor(props)
+  const focusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
 
   return {
     track: {
@@ -39,7 +45,7 @@ const baseStyle = definePartsStyle((props) => {
       p: 0,
       outlineWidth: '1px',
       _focusVisible: {
-        ...layerStyles.focusRing.default._focusVisible,
+        ...focusRingStyle,
         outlineWidth: '1px',
       },
       _focus: {

--- a/react/src/theme/components/Tabs.ts
+++ b/react/src/theme/components/Tabs.ts
@@ -1,6 +1,7 @@
 import { tabsAnatomy as parts } from '@chakra-ui/anatomy'
 import { createMultiStyleConfigHelpers, cssVar } from '@chakra-ui/react'
 import type { StyleFunctionProps } from '@chakra-ui/theme-tools'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 import { textStyles } from '../textStyles'
@@ -48,6 +49,19 @@ const variantLine = definePartsStyle((props) => {
 
   const { color, selectedColor, hoverColor, hoverBg, activeBg, borderColor } =
     getColorsForLineVariant(props)
+
+  const defaultFocusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
+
+  const inverseFocusRingStyle = get(
+    props.theme,
+    'layerStyles.focusRing.inverse._focusVisible',
+    layerStyles.focusRing.inverse._focusVisible,
+  )
+
   return {
     tablist: {
       [borderProp]: '2px solid',
@@ -89,9 +103,9 @@ const variantLine = definePartsStyle((props) => {
         },
       },
       _focusVisible: {
-        ...layerStyles.focusRing.default._focusVisible,
+        ...defaultFocusRingStyle,
         outlineOffset: 0,
-        _dark: layerStyles.focusRing.inverse._focusVisible,
+        _dark: inverseFocusRingStyle,
       },
     },
   }

--- a/react/src/theme/components/Tag.ts
+++ b/react/src/theme/components/Tag.ts
@@ -4,6 +4,7 @@ import {
   defineStyle,
   mergeThemeOverride,
 } from '@chakra-ui/react'
+import { memoizedGet as get } from '@chakra-ui/utils'
 
 import { layerStyles } from '../layerStyles'
 import { textStyles } from '../textStyles'
@@ -15,23 +16,31 @@ const parts = tagAnatomy.extend('icon')
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
-const baseStyleContainer = defineStyle({
-  transitionProperty: 'common',
-  transitionDuration: 'normal',
-  _focusWithin: layerStyles.focusRing.default._focusVisible,
-  borderRadius: 'base',
-  _disabled: {
-    bg: 'interaction.support.disabled',
-    color: 'interaction.support.disabled-content',
-    cursor: 'not-allowed',
-  },
-  _hover: {
+const baseStyleContainer = defineStyle(({ theme }) => {
+  const focusRingStyle = get(
+    theme,
+    'layerStyles.focusRing.default._focusVisible',
+    layerStyles.focusRing.default._focusVisible,
+  )
+
+  return {
+    transitionProperty: 'common',
+    transitionDuration: 'normal',
+    _focusWithin: focusRingStyle,
+    borderRadius: 'base',
     _disabled: {
       bg: 'interaction.support.disabled',
+      color: 'interaction.support.disabled-content',
+      cursor: 'not-allowed',
     },
-  },
-  width: 'fit-content',
-  height: 'fit-content',
+    _hover: {
+      _disabled: {
+        bg: 'interaction.support.disabled',
+      },
+    },
+    width: 'fit-content',
+    height: 'fit-content',
+  }
 })
 
 const baseStyleLabel = defineStyle({
@@ -57,10 +66,12 @@ const baseStyleCloseButton = defineStyle({
   },
 })
 
-const baseStyle = definePartsStyle({
-  container: baseStyleContainer,
-  label: baseStyleLabel,
-  closeButton: baseStyleCloseButton,
+const baseStyle = definePartsStyle((props) => {
+  return {
+    container: baseStyleContainer(props),
+    label: baseStyleLabel,
+    closeButton: baseStyleCloseButton,
+  }
 })
 
 const sizes = {


### PR DESCRIPTION
Currently, to override the focus styles in various components such as a button, users would have to:
1. create a new layer style
2. for every component, override specific focus props to use the imported layer style

This should not happen often, since the current focusRing layer styles depends on the color token `utility.focus.default`, and the color can be changed without touching the layer style declaration simply by changing the `utility.focus.default` color alias to their intended color. However, if users want to change the _style_ of the layer style, there is currently no easy way to do so, until this PR.

This was very tedious and not very extensible.
This PR allows user to only need to do Step 1, and all components that rely on that particular focus layer style should automatically use the user-provided layer style without the need to override the specific component theme (as long as they add the layer style to the application theme).

## Example usage
```ts
// Add new focus layer style as required
// /project/src/theme/layerStyles.ts

const myCustomLayerStyles = {
  focusRing: {
    default: {
      _focusVisible: {
       // whatever style changes you want to do here, for example maybe increase the offset
        outlineOffset: '1.25rem', // don't actually do this, this offset is too much :P
      },
    },
    inverse: {
      _focusVisible: {
        // remember to do the same for `inverse`. Not sure whether the changes are deep or shallow merged, leave it to your experimentation
      },
    },
  },
}
```

Remember to pass new layer styles into your application theme:

```ts
// /project/src/theme/theme.ts


import { layerStyles } from './layerStyles'

export const theme = extendTheme({
  // blablabla
  layerStyles
})
```

another PR will follow for textStyle usage.