### PR TITLE
feat: allow arrow override touchable tooltip

### DIFF
--- a/react/src/Tooltip/Tooltip.tsx
+++ b/react/src/Tooltip/Tooltip.tsx
@@ -37,7 +37,7 @@ export const TouchableTooltip = ({
   const [isLabelOpen, setIsLabelOpen] = useState(!!props.isOpen)
   return (
     <>
-      <ChakraTooltip {...props} hasArrow isOpen={isLabelOpen}>
+      <ChakraTooltip hasArrow {...props} isOpen={isLabelOpen}>
         <Box
           as="span"
           onMouseEnter={() => setIsLabelOpen(true)}

--- a/react/src/Tooltip/Tooltip.tsx
+++ b/react/src/Tooltip/Tooltip.tsx
@@ -54,6 +54,8 @@ export const TouchableTooltip = ({
   )
 }
 
+TouchableTooltip.displayName = 'TouchableTooltip'
+
 /**
  * @deprecated Use `TouchableTooltip` instead.
  *

--- a/react/src/Tooltip/Tooltip.tsx
+++ b/react/src/Tooltip/Tooltip.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import {
+  As,
   Box,
   SystemStyleObject,
   Tooltip as ChakraTooltip,
@@ -13,6 +14,7 @@ export interface TouchableTooltipProps
    * Styles for the container which wraps the children.
    */
   wrapperStyles?: SystemStyleObject
+  wrapperAs?: As
 }
 
 /** @deprecated Use TouchableTooltipProps instead */
@@ -29,6 +31,7 @@ export interface TooltipProps extends TouchableTooltipProps {}
 export const TouchableTooltip = ({
   children,
   wrapperStyles,
+  wrapperAs,
   ...props
 }: TouchableTooltipProps): JSX.Element => {
   // ChakraTooltip does not work on mobile by design. (see
@@ -39,7 +42,7 @@ export const TouchableTooltip = ({
     <>
       <ChakraTooltip hasArrow {...props} isOpen={isLabelOpen}>
         <Box
-          as="span"
+          as={wrapperAs ?? 'span'}
           onMouseEnter={() => setIsLabelOpen(true)}
           onMouseLeave={() => setIsLabelOpen(false)}
           onClick={() => setIsLabelOpen((currentState) => !currentState)}

--- a/react/src/Tooltip/TouchableTooltip.stories.tsx
+++ b/react/src/Tooltip/TouchableTooltip.stories.tsx
@@ -34,9 +34,11 @@ export const CustomChild = Template.bind({})
 CustomChild.args = {
   label: 'Tooltip content goes here',
   children: <Button>Button</Button>,
-  as: 'div',
-  h: 'fit-content',
-  w: 'fit-content',
+  wrapperAs: 'div',
+  wrapperStyles: {
+    h: 'fit-content',
+    w: 'fit-content',
+  },
 }
 
 const TouchableTooltipStack: StoryFn<

--- a/react/src/Tooltip/TouchableTooltip.stories.tsx
+++ b/react/src/Tooltip/TouchableTooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { Box, Icon, Placement, VStack } from '@chakra-ui/react'
+import { Box, Button, Icon, Placement, VStack } from '@chakra-ui/react'
 import { Meta, StoryFn } from '@storybook/react'
 
 import { BxsHelpCircle } from '~/icons/BxsHelpCircle'
@@ -13,49 +13,74 @@ export default {
   decorators: [],
 } as Meta
 
-const TouchableTooltipStack = (
+const Template: StoryFn<TouchableTooltipProps> = ({ children, ...args }) => (
+  <TouchableTooltip {...args}>{children}</TouchableTooltip>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  label: 'Tooltip content goes here',
+  children: <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />,
+}
+
+export const NoArrow = Template.bind({})
+NoArrow.args = {
+  label: 'Tooltip content goes here',
+  children: <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />,
+  hasArrow: false,
+}
+
+export const CustomChild = Template.bind({})
+CustomChild.args = {
+  label: 'Tooltip content goes here',
+  children: <Button>Button</Button>,
+  as: 'div',
+  h: 'fit-content',
+  w: 'fit-content',
+}
+
+const TouchableTooltipStack: StoryFn<
+  TouchableTooltipProps & { labels: { value: string; placement: Placement }[] }
+> = (
   args: TouchableTooltipProps & {
     labels: { value: string; placement: Placement }[]
   },
-): JSX.Element => {
-  return (
-    // bottom margin just so that story snapshot does not get cut off at bottom
-    <VStack align="left" spacing="4rem" mb="4rem">
-      {args.labels.map(({ value, placement }, idx) => (
-        <Box key={idx}>
-          {value}
-          <TouchableTooltip
-            {...args}
-            label="Tooltip content goes here"
-            placement={placement}
-          >
-            <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
-          </TouchableTooltip>
-        </Box>
-      ))}
-    </VStack>
-  )
-}
+) => (
+  // bottom margin just so that story snapshot does not get cut off at bottom
+  <VStack align="left" spacing="4rem" mb="4rem">
+    {args.labels.map(({ value, placement }, idx) => (
+      <Box key={idx}>
+        {value}
+        <TouchableTooltip
+          {...args}
+          label="Tooltip content goes here"
+          placement={placement}
+        >
+          <Icon as={BxsHelpCircle} aria-hidden ml="0.5rem" />
+        </TouchableTooltip>
+      </Box>
+    ))}
+  </VStack>
+)
 
-const Template: StoryFn<TouchableTooltipProps> = (args) => {
-  return (
-    <TouchableTooltipStack
-      {...args}
-      labels={[
-        { value: 'Tooltip on the right', placement: 'right' },
-        {
-          value: "Left (requires longer text so it doesn't flip right)",
-          placement: 'left',
-        },
-        { value: 'Tooltip on top', placement: 'top' },
-        { value: 'Tooltip at bottom', placement: 'bottom' },
-      ]}
-    />
-  )
-}
-export const OnHover = Template.bind({})
+const TemplateGroup: StoryFn<TouchableTooltipProps> = (args) => (
+  <TouchableTooltipStack
+    {...args}
+    labels={[
+      { value: 'Tooltip on the right', placement: 'right' },
+      {
+        value: "Left (requires longer text so it doesn't flip right)",
+        placement: 'left',
+      },
+      { value: 'Tooltip on top', placement: 'top' },
+      { value: 'Tooltip at bottom', placement: 'bottom' },
+    ]}
+  />
+)
 
-export const OpenTooltip = Template.bind({})
+export const OnHover = TemplateGroup.bind({})
+
+export const OpenTooltip = TemplateGroup.bind({})
 OpenTooltip.args = {
   isOpen: true,
 }


### PR DESCRIPTION
Allow touchable tooltip to have no arrows, requested by @prasanthkumaar.