### PR TITLE
fix(inputs): regression with ChakraUI v2.8.2 due to new `height` usage

### DIFF
--- a/react/src/theme/components/Input.ts
+++ b/react/src/theme/components/Input.ts
@@ -78,6 +78,8 @@ const coreSizes = {
       fontSize: themeTextStyles['body-2'].fontSize,
       px: '0.75rem',
       h: '2.25rem',
+      // Override both as Chakra base theme now uses `height`.
+      height: '2.25rem',
     }
   }),
   sm: defineStyle(({ theme }) => {
@@ -87,6 +89,7 @@ const coreSizes = {
       fontSize: themeTextStyles['body-2'].fontSize,
       px: '0.75rem',
       h: '2.5rem',
+      height: '2.5rem',
     }
   }),
   md: defineStyle(({ theme }) => {
@@ -94,6 +97,7 @@ const coreSizes = {
     return {
       px: '1rem',
       h: '2.75rem',
+      height: '2.75rem',
       textStyle: 'body-1',
       fontSize: themeTextStyles['body-1'].fontSize,
     }

--- a/react/src/theme/components/MultiSelect.ts
+++ b/react/src/theme/components/MultiSelect.ts
@@ -54,6 +54,7 @@ const baseStyle = definePartsStyle((props) => {
     icon: {
       display: 'inline-flex',
       h: 'fit-content',
+      height: 'fit-content',
     },
     checkContainer: {
       flexShrink: 0,
@@ -67,6 +68,7 @@ const baseStyle = definePartsStyle((props) => {
     tagIcon: {
       display: 'inline-flex',
       h: 'fit-content',
+      height: 'fit-content',
     },
     field: {
       flexGrow: 1,
@@ -89,6 +91,7 @@ const baseStyle = definePartsStyle((props) => {
             minW: 0,
             minH: 0,
             h: 0,
+            height: 0,
             w: 0,
             opacity: 0,
           }
@@ -145,6 +148,7 @@ const sizes = {
         p: '0.5rem',
         minH: SingleSelect.sizes?.xs(props).field?.h,
         h: 'auto',
+        height: 'auto',
       },
     }),
   ),
@@ -171,6 +175,7 @@ const sizes = {
         p: '0.5rem',
         minH: SingleSelect.sizes?.sm(props).field?.h,
         h: 'auto',
+        height: 'auto',
       },
     }),
   ),
@@ -197,6 +202,7 @@ const sizes = {
         p: '0.5rem',
         minH: SingleSelect.sizes?.md(props).field?.h,
         h: 'auto',
+        height: 'auto',
       },
     }),
   ),


### PR DESCRIPTION
This PR fixes a regression with the `Input` and `MultiSelect` component if users use ChakraUI v2.8.2, where the height of the Input exported by design system is overridden by Chakra's default theme.

This happens because OGPDS's `Input` uses `h` prop alias for height, whilst ChakraUI v2.8.2 switched to using the `height` non-alias prop.

This PR is a fix to allow for backwards compatibility by using both redundant props.