### PR TITLE
fix: allow input change when DatePicker is a controlled component

### DIFF
--- a/react/src/DatePicker/DatePickerContext.tsx
+++ b/react/src/DatePicker/DatePickerContext.tsx
@@ -160,10 +160,13 @@ const useProvideDatePicker = ({
     onChange: onInputValueChange,
   })
 
-  // This effect is responsible for updating the rendered values when the value prop changes.
+  // Update input value when internal value changes.
+  // This allows for any controlled state to update the rendered string too.
   useEffect(() => {
     setInternalInputValue(formatInputValue(internalValue))
-  }, [formatInputValue, internalValue, setInternalInputValue])
+    // Intentionally not including setInternalInputValue so internal input value can actually be changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [internalValue, formatInputValue])
 
   const fcProps = useFormControlProps({
     isInvalid: isInvalidProp,


### PR DESCRIPTION
A bug was introduced in #687 which prevented the input from changing when in a controlled state. This PR fixes that.