### PR TITLE
chore: improve compatibility with modern module resolution

### DIFF
--- a/react/.eslintrc
+++ b/react/.eslintrc
@@ -13,7 +13,10 @@
       "extends": ["plugin:@typescript-eslint/recommended"],
       "parser": "@typescript-eslint/parser",
       "rules": {
-        "@typescript-eslint/no-unused-vars": "warn"
+        "@typescript-eslint/no-unused-vars": ["warn", {
+          "varsIgnorePattern": "^_",
+          "argsIgnorePattern": "^_"
+        }]
       }
     },
     {

--- a/react/src/Attachment/AttachmentError.tsx
+++ b/react/src/Attachment/AttachmentError.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { FileRejection } from 'react-dropzone'
 import {
   Button,
+  ComponentWithAs as _,
   Flex,
   forwardRef,
   Stack,

--- a/react/src/Attachment/AttachmentFileInfo.tsx
+++ b/react/src/Attachment/AttachmentFileInfo.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import {
+  ComponentWithAs as _,
   Flex,
   forwardRef,
   Image,

--- a/react/src/Badge/Badge.tsx
+++ b/react/src/Badge/Badge.tsx
@@ -1,6 +1,7 @@
 import {
   Badge as ChakraBadge,
   BadgeProps as ChakraBadgeProps,
+  ComponentWithAs as _,
   createStylesContext,
   forwardRef,
   Icon,

--- a/react/src/Button/Button.tsx
+++ b/react/src/Button/Button.tsx
@@ -1,6 +1,7 @@
 import {
   Button as ChakraButton,
   ButtonProps as ChakraButtonProps,
+  ComponentWithAs as _,
   forwardRef,
   IconProps,
   ThemingProps,

--- a/react/src/Calendar/Calendar.tsx
+++ b/react/src/Calendar/Calendar.tsx
@@ -1,4 +1,5 @@
 import {
+  ComponentWithAs as _,
   forwardRef,
   Stack,
   StackDivider,

--- a/react/src/Calendar/CalendarBase/CalendarPanel.tsx
+++ b/react/src/Calendar/CalendarBase/CalendarPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import {
   chakra,
+  ComponentWithAs as _,
   forwardRef,
   Stack,
   Text,

--- a/react/src/Calendar/CalendarBase/DayOfMonth.tsx
+++ b/react/src/Calendar/CalendarBase/DayOfMonth.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react'
 import {
   ButtonProps,
   chakra,
+  ComponentWithAs as _,
   Flex,
   forwardRef,
   Skeleton,

--- a/react/src/Calendar/RangeCalendar.tsx
+++ b/react/src/Calendar/RangeCalendar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import {
+  ComponentWithAs as _,
   forwardRef,
   Stack,
   StackDivider,

--- a/react/src/DatePicker/DatePicker.tsx
+++ b/react/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from '@chakra-ui/react'
+import { ComponentWithAs as _, forwardRef } from '@chakra-ui/react'
 
 import { CalendarProps } from '~/Calendar'
 

--- a/react/src/DatePicker/components/DatePickerInput.tsx
+++ b/react/src/DatePicker/components/DatePickerInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import ReactInputMask from 'react-input-mask'
 import {
+  ComponentWithAs as _,
   forwardRef,
   InputGroup,
   InputRightAddon,

--- a/react/src/DateRangePicker/DateRangePicker.tsx
+++ b/react/src/DateRangePicker/DateRangePicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from '@chakra-ui/react'
+import { ComponentWithAs as _, forwardRef } from '@chakra-ui/react'
 
 import { RangeCalendarProps } from '~/Calendar'
 import { DatePickerBaseProps } from '~/DatePicker'

--- a/react/src/DateRangePicker/components/DateRangePickerInput.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import ReactInputMask from 'react-input-mask'
 import {
+  ComponentWithAs as _,
   Flex,
   forwardRef,
   Stack,

--- a/react/src/DateRangePicker/components/DateRangePickerWrapper.tsx
+++ b/react/src/DateRangePicker/components/DateRangePickerWrapper.tsx
@@ -1,4 +1,10 @@
-import { Flex, forwardRef, Popover, PopoverAnchor } from '@chakra-ui/react'
+import {
+  ComponentWithAs as _,
+  Flex,
+  forwardRef,
+  Popover,
+  PopoverAnchor,
+} from '@chakra-ui/react'
 
 import { useDateRangePicker } from '../DateRangePickerContext'
 

--- a/react/src/FormControl/FormLabel/FormLabel.tsx
+++ b/react/src/FormControl/FormLabel/FormLabel.tsx
@@ -2,6 +2,7 @@ import { FC, useMemo } from 'react'
 import {
   Box,
   chakra,
+  ComponentWithAs as _,
   FormHelperText,
   FormLabel as ChakraFormLabel,
   FormLabelProps as ChakraFormLabelProps,

--- a/react/src/IconButton/IconButton.tsx
+++ b/react/src/IconButton/IconButton.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import {
+  ComponentWithAs as _,
   forwardRef,
   IconButton as ChakraIconButton,
   IconButtonProps as ChakraIconButtonProps,

--- a/react/src/Input/Input.tsx
+++ b/react/src/Input/Input.tsx
@@ -1,4 +1,5 @@
 import {
+  ComponentWithAs as _,
   forwardRef,
   Icon,
   Input as ChakraInput,

--- a/react/src/Menu/Menu.stories.tsx
+++ b/react/src/Menu/Menu.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@chakra-ui/react'
 import { Meta, StoryFn } from '@storybook/react'
 
-import { MenuVariant } from '~/theme/components/Menu'
+import { Menu as MenuVariant } from '~/theme/components/Menu'
 
 import { Menu, MenuButtonProps } from './Menu'
 
@@ -27,7 +27,7 @@ type MenuTemplateProps = MenuButtonProps & {
   size?: ThemingProps<'Menu'>['size']
 }
 type MenuGroupTemplateProps = {
-  variant: MenuVariant
+  variant: keyof NonNullable<(typeof MenuVariant)['variants']>
   size?: ThemingProps<'Menu'>['size']
 }
 

--- a/react/src/Menu/Menu.tsx
+++ b/react/src/Menu/Menu.tsx
@@ -1,11 +1,15 @@
 import { FC, useMemo } from 'react'
 import {
+  ComponentWithAs as _,
   Icon,
   Menu as ChakraMenu,
   MenuButton as ChakraMenuButton,
   MenuDivider as ChakraMenuDivider,
+  MenuDividerProps,
   MenuItem as ChakraMenuItem,
+  MenuItemProps,
   MenuList as ChakraMenuList,
+  MenuListProps,
   MenuProps as ChakraMenuProps,
   ThemingProps,
   useMultiStyleConfig,

--- a/react/src/NumberInput/NumberInput.tsx
+++ b/react/src/NumberInput/NumberInput.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import {
   Box,
   chakra,
+  ComponentWithAs as _,
   Divider,
   forwardRef,
   NumberInputProps as ChakraNumberInputProps,

--- a/react/src/PhoneNumberInput/IntlPhoneNumberInput.tsx
+++ b/react/src/PhoneNumberInput/IntlPhoneNumberInput.tsx
@@ -7,6 +7,7 @@
 import { ChangeEvent, FC, useCallback, useMemo } from 'react'
 import {
   chakra,
+  ComponentWithAs as _,
   createStylesContext,
   Flex,
   forwardRef,

--- a/react/src/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/react/src/PhoneNumberInput/PhoneNumberInput.tsx
@@ -4,7 +4,11 @@
  * https://www.npmjs.com/package/react-headless-phone-input but adapted for the
  * application's needs.
  */
-import { forwardRef, useControllableState } from '@chakra-ui/react'
+import {
+  ComponentWithAs as _,
+  forwardRef,
+  useControllableState,
+} from '@chakra-ui/react'
 import { CountryCode, NationalNumber } from 'libphonenumber-js/min'
 
 import { InputProps } from '~/Input'

--- a/react/src/PhoneNumberInput/SingleCountryPhoneNumberInput.tsx
+++ b/react/src/PhoneNumberInput/SingleCountryPhoneNumberInput.tsx
@@ -1,4 +1,5 @@
 import {
+  ComponentWithAs as _,
   forwardRef,
   Icon,
   InputGroup,

--- a/react/src/PhoneNumberInput/utils/countrySelectUtils.ts
+++ b/react/src/PhoneNumberInput/utils/countrySelectUtils.ts
@@ -1,4 +1,4 @@
-import { CountryCode } from 'libphonenumber-js/types'
+import { CountryCode } from 'libphonenumber-js'
 
 /**
  * Simple mapping constant retrieved from

--- a/react/src/RestrictedGovtMasthead/RestrictedGovtMastheadIcon.tsx
+++ b/react/src/RestrictedGovtMasthead/RestrictedGovtMastheadIcon.tsx
@@ -1,4 +1,4 @@
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const RestrictedGovtMastheadIcon = chakra(
   (props: React.SVGProps<SVGSVGElement>): JSX.Element => {

--- a/react/src/Searchbar/Searchbar.tsx
+++ b/react/src/Searchbar/Searchbar.tsx
@@ -1,6 +1,7 @@
 import { KeyboardEvent, useCallback, useRef } from 'react'
 import {
   Box,
+  ComponentWithAs as _,
   forwardRef,
   Icon,
   Input,

--- a/react/src/Sidebar/SidebarHeader.tsx
+++ b/react/src/Sidebar/SidebarHeader.tsx
@@ -1,4 +1,10 @@
-import { Box, chakra, forwardRef, Icon } from '@chakra-ui/react'
+import {
+  Box,
+  chakra,
+  ComponentWithAs as _,
+  forwardRef,
+  Icon,
+} from '@chakra-ui/react'
 
 import { useSidebarStyles } from './SidebarContext'
 import type { BaseSidebarItemProps } from './types'

--- a/react/src/Sidebar/SidebarItem.tsx
+++ b/react/src/Sidebar/SidebarItem.tsx
@@ -1,5 +1,11 @@
 import { useMemo } from 'react'
-import { Box, chakra, forwardRef, Icon } from '@chakra-ui/react'
+import {
+  Box,
+  chakra,
+  ComponentWithAs as _,
+  forwardRef,
+  Icon,
+} from '@chakra-ui/react'
 import { dataAttr, isFunction } from '@chakra-ui/utils'
 import { merge } from 'lodash'
 

--- a/react/src/Sidebar/SidebarList.tsx
+++ b/react/src/Sidebar/SidebarList.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   chakra,
   Collapse,
+  ComponentWithAs as _,
   forwardRef,
   HTMLChakraProps,
   Icon,

--- a/react/src/SingleSelect/utils/itemUtils.ts
+++ b/react/src/SingleSelect/utils/itemUtils.ts
@@ -1,3 +1,5 @@
+import type { As as _ } from '@chakra-ui/react'
+
 import { ComboboxItem } from '../types'
 
 export const itemIsObject = (

--- a/react/src/Switch/Switch.tsx
+++ b/react/src/Switch/Switch.tsx
@@ -6,7 +6,12 @@
 
 import { useMemo } from 'react'
 import { useCheckbox, UseCheckboxProps } from '@chakra-ui/checkbox'
-import { Icon, keyframes, usePrefersReducedMotion } from '@chakra-ui/react'
+import {
+  ComponentWithAs as _,
+  Icon,
+  keyframes,
+  usePrefersReducedMotion,
+} from '@chakra-ui/react'
 import {
   chakra,
   forwardRef,

--- a/react/src/Tag/Tag.tsx
+++ b/react/src/Tag/Tag.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   chakra,
+  ComponentWithAs as _,
   createStylesContext,
   forwardRef,
   HTMLChakraProps,

--- a/react/src/TagInput/TagInput.tsx
+++ b/react/src/TagInput/TagInput.tsx
@@ -8,6 +8,7 @@ import {
 import { RovingTabIndexProvider } from 'react-roving-tabindex'
 import {
   Box,
+  ComponentWithAs as _,
   forwardRef,
   useControllableState,
   useFormControl,

--- a/react/src/TagInput/TagInputInput.tsx
+++ b/react/src/TagInput/TagInputInput.tsx
@@ -5,7 +5,12 @@ import {
   useRef,
 } from 'react'
 import { useFocusEffect, useRovingTabIndex } from 'react-roving-tabindex'
-import { chakra, forwardRef, useMergeRefs } from '@chakra-ui/react'
+import {
+  chakra,
+  ComponentWithAs as _,
+  forwardRef,
+  useMergeRefs,
+} from '@chakra-ui/react'
 
 import { InputProps } from '~/Input'
 

--- a/react/src/Textarea/Textarea.tsx
+++ b/react/src/Textarea/Textarea.tsx
@@ -1,5 +1,6 @@
 import ResizeTextarea, { TextareaAutosizeProps } from 'react-textarea-autosize'
 import {
+  ComponentWithAs as _,
   forwardRef,
   Textarea as ChakraTextarea,
   TextareaProps as ChakraTextareaProps,

--- a/react/src/Toggle/Toggle.tsx
+++ b/react/src/Toggle/Toggle.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useMemo } from 'react'
 import {
   Box,
+  ComponentWithAs as _,
   Flex,
   forwardRef,
   mergeThemeOverride,

--- a/react/src/icons/BxBulb.tsx
+++ b/react/src/icons/BxBulb.tsx
@@ -1,5 +1,5 @@
 // icon:bx-bulb | Boxicons https://boxicons.com/ | Atisa
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxBulb = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxChevronDown.tsx
+++ b/react/src/icons/BxChevronDown.tsx
@@ -1,6 +1,5 @@
 // icon:bx-chevron-down | Boxicons https://boxicons.com/ | Atisa
-
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxChevronDown = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxChevronUp.tsx
+++ b/react/src/icons/BxChevronUp.tsx
@@ -1,6 +1,5 @@
 // icon:bx-chevron-up | Boxicons https://boxicons.com/ | Atisa
-
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxChevronUp = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxGitMerge.tsx
+++ b/react/src/icons/BxGitMerge.tsx
@@ -1,6 +1,5 @@
 // icon:bx-git-merge | Boxicons https://boxicons.com/ | Atisa
-
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxGitMerge = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxLinkExternal.tsx
+++ b/react/src/icons/BxLinkExternal.tsx
@@ -1,4 +1,4 @@
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 // icon:bx-link-external | Boxicons https://boxicons.com/ | Atisa
 export const BxLinkExternal = chakra((props: React.SVGProps<SVGSVGElement>) => {

--- a/react/src/icons/BxLoader.tsx
+++ b/react/src/icons/BxLoader.tsx
@@ -1,6 +1,5 @@
 // icon:bx-loader | Boxicons https://boxicons.com/ | Atisa
-
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxLoader = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxMailSend.tsx
+++ b/react/src/icons/BxMailSend.tsx
@@ -1,6 +1,5 @@
 // icon:bx-mail-send | Boxicons https://boxicons.com/ | Atisa
-
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxMailSend = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxMinus.tsx
+++ b/react/src/icons/BxMinus.tsx
@@ -1,5 +1,5 @@
 // icon:bx-minus | Boxicons https://boxicons.com/ | Atisa
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxMinus = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxPlus.tsx
+++ b/react/src/icons/BxPlus.tsx
@@ -1,5 +1,5 @@
 // icon:bx-plus | Boxicons https://boxicons.com/ | Atisa
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxPlus = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxRightArrowAlt.tsx
+++ b/react/src/icons/BxRightArrowAlt.tsx
@@ -1,6 +1,6 @@
 // icon:bx-right-arrow-alt | Boxicons https://boxicons.com/ | Atisa
 
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxRightArrowAlt = chakra(
   (props: React.SVGProps<SVGSVGElement>) => {

--- a/react/src/icons/BxSearch.tsx
+++ b/react/src/icons/BxSearch.tsx
@@ -1,6 +1,5 @@
 // icon:bx-search | Boxicons https://boxicons.com/ | Atisa
-
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxSearch = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxTrash.tsx
+++ b/react/src/icons/BxTrash.tsx
@@ -1,6 +1,6 @@
 // icon:bx-trash | Boxicons https://boxicons.com/ | Atisa
 
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxTrash = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxUpload.tsx
+++ b/react/src/icons/BxUpload.tsx
@@ -1,5 +1,5 @@
 // icon:bx-upload | Boxicons https://boxicons.com/ | Atisa
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxUpload = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxWrench.tsx
+++ b/react/src/icons/BxWrench.tsx
@@ -1,6 +1,6 @@
 // icon:bx-wrench | Boxicons https://boxicons.com/ | Atisa
 
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxWrench = chakra((props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/react/src/icons/BxX.tsx
+++ b/react/src/icons/BxX.tsx
@@ -1,4 +1,4 @@
-import { chakra } from '@chakra-ui/react'
+import { chakra, ChakraComponent as _ } from '@chakra-ui/react'
 
 export const BxX = chakra(
   (props: React.SVGProps<SVGSVGElement>): JSX.Element => {

--- a/react/src/icons/ToggleChevron.tsx
+++ b/react/src/icons/ToggleChevron.tsx
@@ -1,4 +1,5 @@
 import {
+  ComponentWithAs as _,
   forwardRef,
   Icon,
   type IconProps,

--- a/react/tsconfig.module.json
+++ b/react/tsconfig.module.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "outDir": "build/module",
-    "module": "esnext"
+    "module": "esnext",
+    "moduleResolution": "bundler"
   },
   "exclude": ["node_modules/**"]
 }


### PR DESCRIPTION
## Problem

The modern "bundler" and "NodeNext" module resolution options do not support transitive dependencies properly, leading to errors such as "The inferred type of X cannot be named without reference to Y."

## Solution

A fix is possible by explicitly importing transitive types when they are re-exported.

This results in the generated declaration build changing from
```
import { TextareaAutosizeProps } from 'react-textarea-autosize';
import { TextareaProps as ChakraTextareaProps } from '@chakra-ui/react';
export interface TextareaProps extends ChakraTextareaProps {
    /**
     * The minimum rows the textarea displays on render.
     * Defaults to `3`.
     */
    minAutosizeRows?: TextareaAutosizeProps['minRows'];
    /**
     * The maximum rows the textarea will automatically resize to.
     * Defaults to `6`.
     */
    maxAutosizeRows?: TextareaAutosizeProps['maxRows'];
    /**
     * Whether the input is in a prefilled state.
     */
    isPrefilled?: boolean;
    /**
     * Whether the input is in a success state.
     */
    isSuccess?: boolean;
}
export declare const Textarea: import("@chakra-ui/system/dist/system.types.js").ComponentWithAs<"textarea", TextareaProps>;
```
to 
```
import { TextareaAutosizeProps } from 'react-textarea-autosize';
import { ComponentWithAs as _, TextareaProps as ChakraTextareaProps } from '@chakra-ui/react';
export interface TextareaProps extends ChakraTextareaProps {
    /**
     * The minimum rows the textarea displays on render.
     * Defaults to `3`.
     */
    minAutosizeRows?: TextareaAutosizeProps['minRows'];
    /**
     * The maximum rows the textarea will automatically resize to.
     * Defaults to `6`.
     */
    maxAutosizeRows?: TextareaAutosizeProps['maxRows'];
    /**
     * Whether the input is in a prefilled state.
     */
    isPrefilled?: boolean;
    /**
     * Whether the input is in a success state.
     */
    isSuccess?: boolean;
}
export declare const Textarea: _<"textarea", TextareaProps>;

```