### PR TITLE
fix/reset-date-range-picker

### DIFF
--- a/react/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/react/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -100,4 +100,7 @@ ControlledInput.play = async ({ canvasElement }) => {
       'Select from date picker. Selected date range is Sat Dec 25 2021 to Sun Dec 26 2021.',
     ),
   ).toBeInTheDocument()
+  const resetButton = canvas.getByText('Click to reset')
+  await userEvent.click(resetButton)
+  await expect(canvas.getByText('No date selected')).toBeInTheDocument()
 }

--- a/react/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/react/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -84,6 +84,7 @@ const ControlledTemplate: StoryFn<DateRangePickerProps> = (args) => {
       >
         Click to set date
       </Button>
+      <Button onClick={() => setDatestate([null, null])}>Click to reset</Button>
     </Stack>
   )
 }

--- a/react/src/DateRangePicker/utils.ts
+++ b/react/src/DateRangePicker/utils.ts
@@ -10,11 +10,11 @@ export const validateDateRange = (dateRange: DateRangeValue) => {
   const [start, end] = sortedRange
   return {
     start: {
-      isValid: isValid(start),
+      isValid: isValid(start) || start === null,
       date: start,
     },
     end: {
-      isValid: isValid(end),
+      isValid: isValid(end) || end === null,
       date: end,
     },
   }


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Unable to reset `DateRangePicker` component to `[null, null]` state.

## Solution

_How did you solve the problem?_
allow `null` as valid value in `utils.ts` for start and end.

## Before & After Screenshots

**BEFORE**:
<img width="983" alt="Screenshot 2024-06-11 at 11 51 37 AM" src="https://github.com/opengovsg/design-system/assets/76241201/e46ed844-62bf-4e1b-9108-6045a7184ce6">

**AFTER**:
<img width="1036" alt="Screenshot 2024-06-11 at 11 50 58 AM" src="https://github.com/opengovsg/design-system/assets/76241201/cff7fe7d-3770-4b0a-8288-7aa88a7de078">

## Tests
Added a click to reset button and interactions in storybook to test resetting to `[null, null]`