### PR TITLE
[wip] feat: extend single and multi select with custom value transformer

### DIFF
--- a/react/src/MultiSelect/MultiSelect.stories.tsx
+++ b/react/src/MultiSelect/MultiSelect.stories.tsx
@@ -177,3 +177,50 @@ export const FormInput: StoryFn<MultiSelectProps> = (args) => {
     </FormControl>
   )
 }
+
+export const CustomItemToValueTransformerMultiSelect: StoryFn<
+  MultiSelectProps
+> = (args) => {
+  const [values, setValues] = useState<string[]>(args.values)
+  const items = [
+    {
+      value: 'A',
+      label: 'A',
+      id: 'ID_1',
+      description: 'Label A with value A',
+    },
+    {
+      value: 'A',
+      label: 'B',
+      id: 'ID_2',
+      description: 'Label B with value A',
+    },
+    {
+      value: 'C',
+      label: 'C',
+      id: 'ID_3',
+      description: 'Label C with value C',
+    },
+  ]
+
+  type Item = {
+    value: string
+    label: string
+    id: string
+    description: string
+  }
+
+  function itemToValue(item?: Item) {
+    return item?.id || ''
+  }
+
+  return (
+    <MultiSelect
+      name="test"
+      values={values}
+      onChange={setValues}
+      items={items}
+      itemToValue={itemToValue}
+    />
+  )
+}

--- a/react/src/MultiSelect/MultiSelectProvider.tsx
+++ b/react/src/MultiSelect/MultiSelectProvider.tsx
@@ -25,7 +25,7 @@ import {
   defaultFilter,
   isItemDisabled,
   itemToLabelString,
-  itemToValue,
+  itemToValue as _itemToValue,
 } from '~/SingleSelect/utils'
 
 import { MultiSelectContext } from './MultiSelectContext'
@@ -70,6 +70,10 @@ export interface MultiSelectProviderProps<
    * If `true`, the selected items will take up the full width of the input container. Defaults to `false`.
    */
   isStretchLayout?: boolean
+  /**
+   * Custom transformer to determine the unique identifier for the menu items. Default to using value if not provided.
+   */
+  itemToValue?(item?: Item): string
 }
 export const MultiSelectProvider = ({
   items: rawItems,
@@ -95,6 +99,7 @@ export const MultiSelectProvider = ({
   colorScheme,
   fixedItemHeight,
   isStretchLayout,
+  itemToValue = _itemToValue,
 }: MultiSelectProviderProps): JSX.Element => {
   const theme = useTheme()
   // Required in case size is set in theme, we should respect the one set in theme.
@@ -107,7 +112,7 @@ export const MultiSelectProvider = ({
     [_size, theme?.components?.MultiSelect?.defaultProps?.size],
   )
 
-  const { items, getItemByValue } = useItems({ rawItems })
+  const { items, getItemByValue } = useItems({ rawItems, itemToValue })
   const [isFocused, setIsFocused] = useState(false)
 
   // Inject for components to manipulate

--- a/react/src/SingleSelect/SingleSelect.stories.tsx
+++ b/react/src/SingleSelect/SingleSelect.stories.tsx
@@ -195,3 +195,50 @@ export const FormInput: StoryFn<SingleSelectProps> = (args) => {
     </FormControl>
   )
 }
+
+export const CustomItemToValueTransformerSingleSelect: StoryFn<
+  SingleSelectProps
+> = (args) => {
+  const [value, setValue] = useState<string>(args.value)
+  const items = [
+    {
+      value: 'A',
+      label: 'A',
+      id: 'ID_1',
+      description: 'Label A with value A',
+    },
+    {
+      value: 'A',
+      label: 'B',
+      id: 'ID_2',
+      description: 'Label B with value A',
+    },
+    {
+      value: 'C',
+      label: 'C',
+      id: 'ID_3',
+      description: 'Label C with value C',
+    },
+  ]
+
+  type Item = {
+    value: string
+    label: string
+    id: string
+    description: string
+  }
+
+  function itemToValue(item?: Item) {
+    return item?.id || ''
+  }
+
+  return (
+    <SingleSelect
+      name="test"
+      value={value}
+      onChange={setValue}
+      items={items}
+      itemToValue={itemToValue}
+    />
+  )
+}

--- a/react/src/SingleSelect/SingleSelectProvider.tsx
+++ b/react/src/SingleSelect/SingleSelectProvider.tsx
@@ -11,7 +11,7 @@ import { useCombobox, UseComboboxProps } from 'downshift'
 
 import { useItems } from './hooks/useItems'
 import { defaultFilter } from './utils/defaultFilter'
-import { isItemDisabled, itemToValue } from './utils/itemUtils'
+import { isItemDisabled, itemToValue as _itemToValue } from './utils/itemUtils'
 import { VIRTUAL_LIST_ITEM_HEIGHT } from './constants'
 import { SelectContext, SharedSelectContextReturnProps } from './SelectContext'
 import { ComboboxItem } from './types'
@@ -39,6 +39,10 @@ export interface SingleSelectProviderProps<
   /** Color scheme of component */
   colorScheme?: ThemingProps<'SingleSelect'>['colorScheme']
   fixedItemHeight?: number
+  /**
+   * Custom transformer to determine the unique identifier for the menu items. Default to using value if not provided.
+   */
+  itemToValue?(item?: Item): string
 }
 export const SingleSelectProvider = ({
   items: rawItems,
@@ -62,6 +66,7 @@ export const SingleSelectProvider = ({
   size: _size,
   comboboxProps = {},
   fixedItemHeight,
+  itemToValue = _itemToValue,
 }: SingleSelectProviderProps): JSX.Element => {
   const theme = useTheme()
   // Required in case size is set in theme, we should respect the one set in theme.
@@ -74,7 +79,7 @@ export const SingleSelectProvider = ({
     [_size, theme?.components?.SingleSelect?.defaultProps?.size],
   )
 
-  const { items, getItemByValue } = useItems({ rawItems })
+  const { items, getItemByValue } = useItems({ rawItems, itemToValue })
   const [isFocused, setIsFocused] = useState(false)
 
   const { isInvalid, isDisabled, isReadOnly, isRequired } = useFormControlProps(
@@ -226,7 +231,7 @@ export const SingleSelectProvider = ({
     (item: ComboboxItem) => {
       return !!selectedItem && itemToValue(selectedItem) === itemToValue(item)
     },
-    [selectedItem],
+    [itemToValue, selectedItem],
   )
 
   const resetInputValue = useCallback(() => setInputValue(''), [setInputValue])

--- a/react/src/SingleSelect/components/DropdownItem/DropdownItem.tsx
+++ b/react/src/SingleSelect/components/DropdownItem/DropdownItem.tsx
@@ -22,7 +22,7 @@ export const DropdownItem = ({
   item,
   index,
 }: DropdownItemProps): JSX.Element => {
-  const { getItemProps, isItemSelected, inputValue, styles } =
+  const { getItemProps, isItemSelected, selectedItem, inputValue, styles } =
     useSelectContext()
 
   const { icon, label, description, isDisabled, isActive } = useMemo(
@@ -31,9 +31,9 @@ export const DropdownItem = ({
       label: itemToLabelString(item),
       description: itemToDescriptionString(item),
       isDisabled: isItemDisabled(item),
-      isActive: isItemSelected(item),
+      isActive: isItemSelected(item, selectedItem),
     }),
-    [isItemSelected, item],
+    [isItemSelected, selectedItem, item],
   )
 
   return (

--- a/react/src/SingleSelect/hooks/useItems.ts
+++ b/react/src/SingleSelect/hooks/useItems.ts
@@ -3,7 +3,6 @@
 import { useCallback, useMemo } from 'react'
 
 import { ComboboxItem } from '../types'
-import { itemToValue } from '../utils/itemUtils'
 
 export type ItemWithIndex<Item extends ComboboxItem = ComboboxItem> = {
   item: Item
@@ -16,10 +15,12 @@ export type UseItemsReturn<Item extends ComboboxItem = ComboboxItem> = {
 
 interface UseItemProps<Item extends ComboboxItem = ComboboxItem> {
   rawItems: Item[]
+  itemToValue: <Item extends ComboboxItem>(item?: Item | undefined) => string
 }
 
 export const useItems = <Item extends ComboboxItem = ComboboxItem>({
   rawItems,
+  itemToValue,
 }: UseItemProps<Item>) => {
   const normalizedItems = useMemo(() => {
     const initialStore: UseItemsReturn<Item> = {
@@ -45,7 +46,7 @@ export const useItems = <Item extends ComboboxItem = ComboboxItem>({
       itemIndex++
       return store
     }, initialStore)
-  }, [rawItems])
+  }, [rawItems, itemToValue])
 
   const getItemByValue = useCallback(
     (value: string): ItemWithIndex<Item> | null => {


### PR DESCRIPTION
[TBH]
- no use case imo. you can just extend your own object. then use value as your identifer, and then get the real value from another field ...

- is itemToValue name too confusing? since technically there is a value field but this is an overriding.
- this will result in the value being from the transformer instead of the `value` field in the object