### PR TITLE
fix!(DatePicker): add `renderInputElement` prop

### DIFF
--- a/react/src/DatePicker/DatePicker.stories.tsx
+++ b/react/src/DatePicker/DatePicker.stories.tsx
@@ -96,12 +96,12 @@ const CustomInputButton = forwardRef<object, 'button'>((_props, ref) => {
 
 export const CustomInput = Template.bind({})
 CustomInput.args = {
-  inputElement: <CustomInputButton />,
+  renderInputElement: () => <CustomInputButton />,
 }
 
 export const MobileCustomInput = Template.bind({})
 MobileCustomInput.args = {
-  inputElement: <CustomInputButton />,
+  renderInputElement: () => <CustomInputButton />,
 }
 MobileCustomInput.parameters = getMobileViewParameters()
 

--- a/react/src/DatePicker/DatePickerContext.tsx
+++ b/react/src/DatePicker/DatePickerContext.tsx
@@ -49,6 +49,7 @@ interface DatePickerContextReturn {
   size?: ThemingProps<'DatePicker'>['size']
   disclosureProps: UseDisclosureReturn
   renderInputElement?: () => React.ReactNode
+  inputElement?: React.ReactNode
   innerRef?: React.Ref<HTMLElement>
   calendarProps: Pick<
     CalendarProps,
@@ -113,6 +114,7 @@ const useProvideDatePicker = ({
   ssr,
   size,
   experimental_forceIosNumberKeyboard,
+  inputElement,
   renderInputElement,
   innerRef,
   ...props
@@ -286,7 +288,8 @@ const useProvideDatePicker = ({
     disclosureProps,
     calendarProps,
     inputPattern,
-    renderInputElement: renderInputElement,
+    inputElement,
+    renderInputElement,
     innerRef,
   }
 }

--- a/react/src/DatePicker/DatePickerContext.tsx
+++ b/react/src/DatePicker/DatePickerContext.tsx
@@ -48,7 +48,7 @@ interface DatePickerContextReturn {
   colorScheme?: ThemingProps<'DatePicker'>['colorScheme']
   size?: ThemingProps<'DatePicker'>['size']
   disclosureProps: UseDisclosureReturn
-  inputElement?: React.ReactNode
+  renderInputElement?: () => React.ReactNode
   innerRef?: React.Ref<HTMLElement>
   calendarProps: Pick<
     CalendarProps,
@@ -113,7 +113,7 @@ const useProvideDatePicker = ({
   ssr,
   size,
   experimental_forceIosNumberKeyboard,
-  inputElement,
+  renderInputElement,
   innerRef,
   ...props
 }: DatePickerProviderProps): DatePickerContextReturn => {
@@ -286,7 +286,7 @@ const useProvideDatePicker = ({
     disclosureProps,
     calendarProps,
     inputPattern,
-    inputElement,
+    renderInputElement: renderInputElement,
     innerRef,
   }
 }

--- a/react/src/DatePicker/components/DatePickerWrapper.tsx
+++ b/react/src/DatePicker/components/DatePickerWrapper.tsx
@@ -13,11 +13,12 @@ export const DatePickerWrapper = ({ children }: PropsWithChildren) => {
     closeCalendarOnChange,
     isMobile,
     renderInputElement,
+    inputElement,
   } = useDatePicker()
 
   const inputToRender = useMemo(() => {
-    return renderInputElement?.() ?? <DatePickerInput />
-  }, [renderInputElement])
+    return renderInputElement?.() ?? inputElement ?? <DatePickerInput />
+  }, [inputElement, renderInputElement])
 
   if (isMobile) {
     return (

--- a/react/src/DatePicker/components/DatePickerWrapper.tsx
+++ b/react/src/DatePicker/components/DatePickerWrapper.tsx
@@ -12,12 +12,12 @@ export const DatePickerWrapper = ({ children }: PropsWithChildren) => {
     initialFocusRef,
     closeCalendarOnChange,
     isMobile,
-    inputElement,
+    renderInputElement,
   } = useDatePicker()
 
   const inputToRender = useMemo(() => {
-    return inputElement ?? <DatePickerInput />
-  }, [inputElement])
+    return renderInputElement?.() ?? <DatePickerInput />
+  }, [renderInputElement])
 
   if (isMobile) {
     return (

--- a/react/src/DatePicker/types.ts
+++ b/react/src/DatePicker/types.ts
@@ -48,5 +48,14 @@ export interface DatePickerBaseProps
   refocusOnClose?: boolean
   /** date-fns's Locale of the date to be applied if provided. */
   locale?: Locale
+  /**
+   * @deprecated use `renderInputElement` instead. If `renderInputElement` is provided,
+   * that will take precedence over `inputElement`.
+   */
+  inputElement?: React.ReactElement
+  /**
+   * If provided, the value will be used instead of the default `DatePickerInput` component.
+   * @returns
+   */
   renderInputElement?: () => React.ReactElement
 }

--- a/react/src/DatePicker/types.ts
+++ b/react/src/DatePicker/types.ts
@@ -48,5 +48,5 @@ export interface DatePickerBaseProps
   refocusOnClose?: boolean
   /** date-fns's Locale of the date to be applied if provided. */
   locale?: Locale
-  inputElement?: React.ReactElement
+  renderInputElement?: () => React.ReactElement
 }


### PR DESCRIPTION
This allows users to use datepicker hooks in their custom input component.
Currently, if `useDatepicker` hook is used in the custom input element,
react will throw (since the custom component is instantiated without a datepicker parent)