### PR TITLE
chore: use portal by default in avatar menu

### DIFF
--- a/react/src/AvatarMenu/AvatarMenu.tsx
+++ b/react/src/AvatarMenu/AvatarMenu.tsx
@@ -6,6 +6,7 @@ import {
   MenuDivider,
   MenuListProps,
   MenuProps,
+  Portal,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 import { merge } from 'lodash'
@@ -78,9 +79,11 @@ export const AvatarMenu = ({
               {hasNotification && badge}
             </Avatar>
           </AvatarMenuButton>
-          <Menu.List role="menu" sx={styles.list} {...menuListProps}>
-            {children}
-          </Menu.List>
+          <Portal>
+            <Menu.List role="menu" sx={styles.list} {...menuListProps}>
+              {children}
+            </Menu.List>
+          </Portal>
         </>
       )}
     </Menu>


### PR DESCRIPTION
## Problem
Bright uses the AvatarMenu in the app NavBar, which is a fairly typical use case. It is as sticky bar, which creates its own stacking context. Unrelated ancestor props like maxHeight or overflow then cause issues for the AvatarMenu.

## Solution
There's rarely a reason not to [use Menu with Portal](https://v2.chakra-ui.com/docs/components/menu#rendering-menu-in-a-portal). This changes `AvatarMenu` to do that, without changing the component signature.

### Alternative considered
Accept a new custom prop like `withPortal`. Rejected because it is custom, and it feels acceptable to deny users the option to not use portal. 

