### PR TITLE
fix: SingleSelect bug with disabled items

### DIFF
--- a/packages/camp/src/SingleSelect/components/DropdownItem/DropdownItem.tsx
+++ b/packages/camp/src/SingleSelect/components/DropdownItem/DropdownItem.tsx
@@ -43,8 +43,9 @@ export const DropdownItem = ({
       {...getItemProps({
         item,
         index,
-        disabled: isDisabled,
       })}
+      aria-disabled={isDisabled || undefined}
+      data-disabled={dataAttr(isDisabled)}
     >
       <Flex flexDir="column">
         <Stack direction="row" align="center" spacing="1rem">

--- a/packages/camp/src/theme/components/Menu.ts
+++ b/packages/camp/src/theme/components/Menu.ts
@@ -9,6 +9,11 @@ const { definePartsStyle, defineMultiStyleConfig } =
 
 const $bg = cssVar('menu-bg')
 const $shadow = cssVar('menu-shadow')
+const disabledItemStyles = {
+  color: 'interaction.support.disabled-content',
+  opacity: 1,
+  cursor: 'not-allowed',
+}
 
 const getListItemColors = ({ colorScheme: c }: StyleFunctionProps) => {
   switch (c) {
@@ -54,10 +59,15 @@ const baseStyle = definePartsStyle((props) => {
       _hover: {
         [$bg.variable]: `colors.${hoverBg}`,
       },
-      _disabled: {
-        color: 'interaction.support.disabled-content',
-        opacity: 1,
-        cursor: 'not-allowed',
+      _disabled: disabledItemStyles,
+      '&[aria-disabled=true], &[data-disabled]': {
+        ...disabledItemStyles,
+        _hover: {
+          [$bg.variable]: 'colors.utility.ui',
+        },
+        _active: {
+          [$bg.variable]: 'colors.utility.ui',
+        },
       },
       _focus: {
         [$bg.variable]: `colors.${hoverBg}`,


### PR DESCRIPTION
## Problem

See bug description in issue #1032 

Closes issue #1032 

## Solution

Implemented the SingleSelect disabled-handling fix to stop Downshift from touching missing DOM nodes when virtualized lists contain disabled items.

* Updated packages/camp/src/SingleSelect/components/DropdownItem/DropdownItem.tsx to stop passing disabled into getItemProps and instead mark disabled options with aria-disabled/data-disabled for styling without triggering Downshift’s DOM lookup.
* Added keyboard navigation normalization in packages/camp/src/SingleSelect/SingleSelectProvider.tsx so arrow key moves skip over disabled entries using filteredItems, avoiding crashes when items aren’t mounted.
* Extended menu theming in packages/camp/src/theme/components/Menu.ts to style items marked via aria-disabled/data-disabled, preserving the disabled appearance without relying on the disabled attribute.


## Tests

- [x] Tested the bug fix in local storybook. See videos below:

https://github.com/user-attachments/assets/f951025e-e143-4e34-a1df-7ae00e6f1e7d


## Deploy Notes

NA