### PR TITLE
feat(camp): migrate Breadcrumb to Chakra UI v3

### DIFF
--- a/packages/camp/src/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/camp/src/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,91 @@
+import { Separator, Stack } from '@chakra-ui/react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  type BreadcrumbProps,
+} from './'
+
+export default {
+  title: 'Components/Breadcrumb',
+  component: Breadcrumb,
+  tags: ['autodocs'],
+  args: {
+    size: 'md',
+  },
+} as Meta<BreadcrumbProps>
+
+const BreadcrumbTemplate: StoryFn<BreadcrumbProps> = (args) => (
+  <Breadcrumb {...args}>
+    <Breadcrumb.Item>
+      <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Item>
+      <Breadcrumb.Link href="#">Docs</Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Item>
+      <Breadcrumb.CurrentLink>{`Breadcrumb ${
+        args.size ?? ''
+      }`}</Breadcrumb.CurrentLink>
+    </Breadcrumb.Item>
+  </Breadcrumb>
+)
+
+export const Default = BreadcrumbTemplate.bind({})
+
+export const HoverFocusStates: StoryFn<BreadcrumbProps> = () => (
+  <Breadcrumb>
+    <Breadcrumb.Item>
+      <Breadcrumb.Link data-hover href="#">
+        Home
+      </Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Item>
+      <Breadcrumb.Link data-focus-visible href="#">
+        Docs
+      </Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Item>
+      <Breadcrumb.CurrentLink>Breadcrumb</Breadcrumb.CurrentLink>
+    </Breadcrumb.Item>
+  </Breadcrumb>
+)
+
+export const SlashSeparator = BreadcrumbTemplate.bind({})
+SlashSeparator.args = { separator: '/' }
+
+export const NoSeparator = BreadcrumbTemplate.bind({})
+NoSeparator.args = { separator: null }
+
+// Covers the deprecated v1 alias re-exports (BreadcrumbItem / BreadcrumbLink).
+export const WithDeprecatedAliases: StoryFn<BreadcrumbProps> = (args) => (
+  <Breadcrumb {...args}>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Home</BreadcrumbLink>
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <Breadcrumb.CurrentLink>Settings</Breadcrumb.CurrentLink>
+    </BreadcrumbItem>
+  </Breadcrumb>
+)
+
+export const Sizes: StoryFn<BreadcrumbProps> = () => (
+  <Stack>
+    <BreadcrumbTemplate size="xs" />
+    <BreadcrumbTemplate size="sm" />
+    <BreadcrumbTemplate size="md" />
+    <Separator />
+    <BreadcrumbTemplate separator="/" size="xs" />
+    <BreadcrumbTemplate separator="/" size="sm" />
+    <BreadcrumbTemplate separator="/" size="md" />
+  </Stack>
+)

--- a/packages/camp/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/camp/src/Breadcrumb/Breadcrumb.tsx
@@ -13,7 +13,7 @@ export interface BreadcrumbProps
    * Each child should be a `<Breadcrumb.Item>`. Separators are auto-inserted
    * between consecutive items.
    */
-  children: React.ReactNode
+  children?: React.ReactNode
   /**
    * Separator rendered between items. Defaults to a chevron-right icon.
    * Pass a string (e.g. `'/'`) or any `ReactElement` to override; pass

--- a/packages/camp/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/camp/src/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,97 @@
+import { Children, forwardRef, Fragment, isValidElement } from 'react'
+import {
+  Breadcrumb as ChakraBreadcrumb,
+  type BreadcrumbRootProps as ChakraBreadcrumbRootProps,
+} from '@chakra-ui/react'
+
+import { BxChevronRight } from '~/icons'
+import type { BreadcrumbColorPalette } from '~/theme/slotRecipes/breadcrumb.slotRecipe'
+
+export interface BreadcrumbProps
+  extends Omit<ChakraBreadcrumbRootProps, 'colorPalette'> {
+  /**
+   * Each child should be a `<Breadcrumb.Item>` (the wrapper auto-injects
+   * `<Breadcrumb.Separator>` between consecutive items).
+   *
+   * The legacy v1 `<BreadcrumbItem>` / `<BreadcrumbLink>` exports still work
+   * via deprecated re-exports.
+   */
+  children: React.ReactNode
+  /**
+   * Separator rendered between items. Defaults to a chevron-right icon.
+   * Pass a string (e.g. `'/'`) or any `ReactElement` to override; pass
+   * `null` to render no separator.
+   */
+  separator?: React.ReactNode
+  colorPalette?:
+    | ChakraBreadcrumbRootProps['colorPalette']
+    | BreadcrumbColorPalette
+}
+
+/**
+ * Convenience wrapper around v3's `Breadcrumb` compound. Auto-builds the
+ * `Breadcrumb.Root` / `Breadcrumb.List` scaffold and interleaves
+ * `Breadcrumb.Separator` nodes between consumer-provided items — preserving
+ * v1's `<Breadcrumb separator="/">` ergonomics.
+ *
+ * For full slot composition (mixing separators per item, conditional
+ * `Ellipsis`, etc.) use the compound API directly:
+ *
+ * ```tsx
+ * <Breadcrumb.Root>
+ *   <Breadcrumb.List>
+ *     <Breadcrumb.Item>...</Breadcrumb.Item>
+ *     <Breadcrumb.Separator><BxChevronRight /></Breadcrumb.Separator>
+ *     <Breadcrumb.Item>...</Breadcrumb.Item>
+ *   </Breadcrumb.List>
+ * </Breadcrumb.Root>
+ * ```
+ */
+const BreadcrumbInner = forwardRef<HTMLElement, BreadcrumbProps>(
+  ({ children, separator = <BxChevronRight />, ...rootProps }, ref) => {
+    const items = Children.toArray(children).filter(isValidElement)
+
+    return (
+      <ChakraBreadcrumb.Root ref={ref} {...rootProps}>
+        <ChakraBreadcrumb.List>
+          {items.map((item, index) => (
+            <Fragment key={index}>
+              {item}
+              {separator !== null && index < items.length - 1 ? (
+                <ChakraBreadcrumb.Separator>
+                  {separator}
+                </ChakraBreadcrumb.Separator>
+              ) : null}
+            </Fragment>
+          ))}
+        </ChakraBreadcrumb.List>
+      </ChakraBreadcrumb.Root>
+    )
+  },
+)
+BreadcrumbInner.displayName = 'Breadcrumb'
+
+// Attach all v3 sub-components to the wrapper namespace so consumers can
+// reach for `Breadcrumb.Item`, `Breadcrumb.Link`, etc. without a separate
+// import. v3's namespace itself is frozen — spread (Avatar / Tag precedent).
+export const Breadcrumb: typeof BreadcrumbInner & typeof ChakraBreadcrumb =
+  Object.assign(BreadcrumbInner, { ...ChakraBreadcrumb })
+
+// --- Deprecated v1 aliases ---------------------------------------------------
+
+/** @deprecated Use `Breadcrumb.Item` instead. */
+export const BreadcrumbItem = ChakraBreadcrumb.Item
+/** @deprecated Use `Breadcrumb.Link` instead. */
+export const BreadcrumbLink = ChakraBreadcrumb.Link
+
+export type {
+  BreadcrumbCurrentLinkProps,
+  BreadcrumbEllipsisProps,
+  BreadcrumbItemProps,
+  BreadcrumbLinkProps,
+  BreadcrumbListProps,
+  BreadcrumbRootProps,
+  BreadcrumbSeparatorProps,
+} from '@chakra-ui/react'
+
+export type { BreadcrumbColorPalette }

--- a/packages/camp/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/camp/src/Breadcrumb/Breadcrumb.tsx
@@ -10,11 +10,8 @@ import type { BreadcrumbColorPalette } from '~/theme/slotRecipes/breadcrumb.slot
 export interface BreadcrumbProps
   extends Omit<ChakraBreadcrumbRootProps, 'colorPalette'> {
   /**
-   * Each child should be a `<Breadcrumb.Item>` (the wrapper auto-injects
-   * `<Breadcrumb.Separator>` between consecutive items).
-   *
-   * The legacy v1 `<BreadcrumbItem>` / `<BreadcrumbLink>` exports still work
-   * via deprecated re-exports.
+   * Each child should be a `<Breadcrumb.Item>`. Separators are auto-inserted
+   * between consecutive items.
    */
   children: React.ReactNode
   /**
@@ -29,23 +26,18 @@ export interface BreadcrumbProps
 }
 
 /**
- * Convenience wrapper around v3's `Breadcrumb` compound. Auto-builds the
+ * Wrapper around the Chakra `Breadcrumb` compound. Builds the
  * `Breadcrumb.Root` / `Breadcrumb.List` scaffold and interleaves
- * `Breadcrumb.Separator` nodes between consumer-provided items — preserving
- * v1's `<Breadcrumb separator="/">` ergonomics.
- *
- * For full slot composition (mixing separators per item, conditional
- * `Ellipsis`, etc.) use the compound API directly:
+ * `Breadcrumb.Separator` nodes between children, so consumers can write:
  *
  * ```tsx
- * <Breadcrumb.Root>
- *   <Breadcrumb.List>
- *     <Breadcrumb.Item>...</Breadcrumb.Item>
- *     <Breadcrumb.Separator><BxChevronRight /></Breadcrumb.Separator>
- *     <Breadcrumb.Item>...</Breadcrumb.Item>
- *   </Breadcrumb.List>
- * </Breadcrumb.Root>
+ * <Breadcrumb separator="/">
+ *   <Breadcrumb.Item>…</Breadcrumb.Item>
+ *   <Breadcrumb.Item>…</Breadcrumb.Item>
+ * </Breadcrumb>
  * ```
+ *
+ * For per-item separator control, use the compound API directly.
  */
 const BreadcrumbInner = forwardRef<HTMLElement, BreadcrumbProps>(
   ({ children, separator = <BxChevronRight />, ...rootProps }, ref) => {
@@ -71,13 +63,8 @@ const BreadcrumbInner = forwardRef<HTMLElement, BreadcrumbProps>(
 )
 BreadcrumbInner.displayName = 'Breadcrumb'
 
-// Attach all v3 sub-components to the wrapper namespace so consumers can
-// reach for `Breadcrumb.Item`, `Breadcrumb.Link`, etc. without a separate
-// import. v3's namespace itself is frozen — spread (Avatar / Tag precedent).
 export const Breadcrumb: typeof BreadcrumbInner & typeof ChakraBreadcrumb =
   Object.assign(BreadcrumbInner, { ...ChakraBreadcrumb })
-
-// --- Deprecated v1 aliases ---------------------------------------------------
 
 /** @deprecated Use `Breadcrumb.Item` instead. */
 export const BreadcrumbItem = ChakraBreadcrumb.Item

--- a/packages/camp/src/Breadcrumb/index.ts
+++ b/packages/camp/src/Breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from './Breadcrumb'

--- a/packages/camp/src/index.ts
+++ b/packages/camp/src/index.ts
@@ -1,5 +1,6 @@
 export * from './Avatar'
 export * from './Badge'
+export * from './Breadcrumb'
 export * from './Button'
 export * from './IconButton'
 export * from './icons'

--- a/packages/camp/src/theme/config.ts
+++ b/packages/camp/src/theme/config.ts
@@ -4,6 +4,7 @@ import { badgeRecipe } from './recipes/badge.recipe'
 import { buttonRecipe } from './recipes/button.recipe'
 import { linkRecipe } from './recipes/link.recipe'
 import { avatarSlotRecipe } from './slotRecipes/avatar.slotRecipe'
+import { breadcrumbSlotRecipe } from './slotRecipes/breadcrumb.slotRecipe'
 import { tagSlotRecipe } from './slotRecipes/tag.slotRecipe'
 import { breakpoints } from './breakpoints'
 import { layerStyles } from './layerStyles'
@@ -46,6 +47,7 @@ export const config = defineConfig({
     },
     slotRecipes: {
       avatar: avatarSlotRecipe,
+      breadcrumb: breadcrumbSlotRecipe,
       tag: tagSlotRecipe,
     },
   },

--- a/packages/camp/src/theme/slotRecipes/breadcrumb.slotRecipe.ts
+++ b/packages/camp/src/theme/slotRecipes/breadcrumb.slotRecipe.ts
@@ -1,0 +1,97 @@
+import { defineSlotRecipe } from '@chakra-ui/react'
+
+export type BreadcrumbColorPalette = 'main' | 'sub' | 'neutral'
+
+/**
+ * @deprecated Renamed to `BreadcrumbColorPalette`. Will be removed in v3.
+ */
+export type ThemeBreadcrumbColorScheme = BreadcrumbColorPalette
+
+/**
+ * Breadcrumb slot recipe — overrides only the properties v1 diverged on.
+ *
+ * v1 component: `git show main:packages/camp/src/theme/components/Breadcrumb.ts`.
+ * v1 had no React wrapper around theming — just a thin wrapper injecting
+ * a default `BxChevronRight` separator. Theme drove typography per size.
+ *
+ * v1 differences from v3 defaults:
+ * - Sizes: v1 has `xs/sm/md`; v3 has `sm/md/lg`. Full size set overridden so
+ *   `<Breadcrumb size="xs">` still works in consumer code without rename.
+ * - Link uses our `utility.focus-default` focus ring (matches Link/Button
+ *   recipes) rather than v3's `focusRing: 'outside'` token chain.
+ * - Hover swaps text-decoration via CSS var (v1 used `cssVar('breadcrumb-link-decor')`)
+ *   — re-implemented inline so we don't depend on chakra-utils v2 helpers.
+ * - Separator inherits v3 default styling; we keep the muted colour but
+ *   redeclare textStyle per-size since v3 doesn't drive that for the
+ *   separator slot.
+ *
+ * Per audit § 8 #14: v3-default size variants set `gap` / `textStyle` on
+ * `list`. We override per-size.
+ *
+ * Per audit § 8 #16: no `className` field set; v3 defaults to `chakra-breadcrumb`.
+ */
+export const breadcrumbSlotRecipe = defineSlotRecipe({
+  slots: [
+    'root',
+    'list',
+    'item',
+    'link',
+    'currentLink',
+    'separator',
+    'ellipsis',
+  ],
+  base: {
+    link: {
+      transitionProperty: 'common',
+      transitionDuration: 'fast',
+      transitionTimingFunction: 'ease-out',
+      outline: 'none',
+      color: 'base.content.default',
+      textDecoration: 'none',
+      borderRadius: 'sm',
+      // v1 wired link styling so that only non-current links pick up hover
+      // underline and focus ring. The `data-current=page` attribute is the
+      // v3 idiom for the active step.
+      "&:not([data-current='page'])": {
+        cursor: 'pointer',
+        _hover: {
+          textDecoration: 'underline',
+        },
+        outlineOffset: '0.25rem',
+        _focusVisible: {
+          boxShadow: 'none',
+          outline: '2px solid var(--chakra-colors-utility-focus-default)',
+          outlineOffset: '0.25rem',
+        },
+      },
+    },
+    currentLink: {
+      // v1 used the same colour token for current and non-current links.
+      // v3 default split them into `currentLink` (full `fg`) and `link`
+      // (`fg.muted`). Re-unify so the active step matches v1 typography.
+      color: 'base.content.default',
+    },
+    separator: {
+      color: 'interaction.support.disabled-content',
+    },
+  },
+  variants: {
+    size: {
+      xs: {
+        list: { textStyle: 'caption-1' },
+        separator: { textStyle: 'caption-1' },
+      },
+      sm: {
+        list: { textStyle: 'subhead-2' },
+        separator: { textStyle: 'subhead-2' },
+      },
+      md: {
+        list: { textStyle: 'subhead-1' },
+        separator: { textStyle: 'subhead-1' },
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+})

--- a/packages/camp/src/theme/slotRecipes/breadcrumb.slotRecipe.ts
+++ b/packages/camp/src/theme/slotRecipes/breadcrumb.slotRecipe.ts
@@ -2,34 +2,9 @@ import { defineSlotRecipe } from '@chakra-ui/react'
 
 export type BreadcrumbColorPalette = 'main' | 'sub' | 'neutral'
 
-/**
- * @deprecated Renamed to `BreadcrumbColorPalette`. Will be removed in v3.
- */
+/** @deprecated Renamed to `BreadcrumbColorPalette`. */
 export type ThemeBreadcrumbColorScheme = BreadcrumbColorPalette
 
-/**
- * Breadcrumb slot recipe — overrides only the properties v1 diverged on.
- *
- * v1 component: `git show main:packages/camp/src/theme/components/Breadcrumb.ts`.
- * v1 had no React wrapper around theming — just a thin wrapper injecting
- * a default `BxChevronRight` separator. Theme drove typography per size.
- *
- * v1 differences from v3 defaults:
- * - Sizes: v1 has `xs/sm/md`; v3 has `sm/md/lg`. Full size set overridden so
- *   `<Breadcrumb size="xs">` still works in consumer code without rename.
- * - Link uses our `utility.focus-default` focus ring (matches Link/Button
- *   recipes) rather than v3's `focusRing: 'outside'` token chain.
- * - Hover swaps text-decoration via CSS var (v1 used `cssVar('breadcrumb-link-decor')`)
- *   — re-implemented inline so we don't depend on chakra-utils v2 helpers.
- * - Separator inherits v3 default styling; we keep the muted colour but
- *   redeclare textStyle per-size since v3 doesn't drive that for the
- *   separator slot.
- *
- * Per audit § 8 #14: v3-default size variants set `gap` / `textStyle` on
- * `list`. We override per-size.
- *
- * Per audit § 8 #16: no `className` field set; v3 defaults to `chakra-breadcrumb`.
- */
 export const breadcrumbSlotRecipe = defineSlotRecipe({
   slots: [
     'root',
@@ -49,9 +24,6 @@ export const breadcrumbSlotRecipe = defineSlotRecipe({
       color: 'base.content.default',
       textDecoration: 'none',
       borderRadius: 'sm',
-      // v1 wired link styling so that only non-current links pick up hover
-      // underline and focus ring. The `data-current=page` attribute is the
-      // v3 idiom for the active step.
       "&:not([data-current='page'])": {
         cursor: 'pointer',
         _hover: {
@@ -66,9 +38,6 @@ export const breadcrumbSlotRecipe = defineSlotRecipe({
       },
     },
     currentLink: {
-      // v1 used the same colour token for current and non-current links.
-      // v3 default split them into `currentLink` (full `fg`) and `link`
-      // (`fg.muted`). Re-unify so the active step matches v1 typography.
       color: 'base.content.default',
     },
     separator: {

--- a/packages/camp/src/theme/slotRecipes/index.ts
+++ b/packages/camp/src/theme/slotRecipes/index.ts
@@ -3,5 +3,10 @@ export type {
   ThemeAvatarColorScheme,
 } from './avatar.slotRecipe'
 export { avatarSlotRecipe } from './avatar.slotRecipe'
+export type {
+  BreadcrumbColorPalette,
+  ThemeBreadcrumbColorScheme,
+} from './breadcrumb.slotRecipe'
+export { breadcrumbSlotRecipe } from './breadcrumb.slotRecipe'
 export type { TagColorPalette, ThemeTagColorScheme } from './tag.slotRecipe'
 export { tagSlotRecipe } from './tag.slotRecipe'


### PR DESCRIPTION
Author a slot recipe overriding v3 defaults to match v1:
- xs/sm/md sizes with caption-1 / subhead-2 / subhead-1 textStyles
  (v3 default ships sm/md/lg only).
- Unified link colour for current and non-current steps; v3 default split
  these into different `fg` / `fg.muted` tokens.
- Custom focus ring using utility.focus-default token to match Link /
  Button / Tag focus styling.
- Hover underline via `_hover` (v1 used a CSS-var dance; v3 lets us write
  the direct `text-decoration` toggle).

Wrap v3's compound `Breadcrumb` namespace so consumers can keep the v1-style
single-element API (`<Breadcrumb separator="/">{items}</Breadcrumb>`). The
wrapper injects `BxChevronRight` as the default separator and interleaves
`Breadcrumb.Separator` nodes between children.

Deprecated re-exports retain `BreadcrumbItem` / `BreadcrumbLink` so v1
consumer code compiles unchanged.