### PR TITLE
feat(camp): migrate Banner to Chakra UI v3

### DIFF
--- a/packages/camp/src/Banner/Banner.stories.tsx
+++ b/packages/camp/src/Banner/Banner.stories.tsx
@@ -1,0 +1,54 @@
+import { Stack } from '@chakra-ui/react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { Banner, type BannerProps } from './'
+
+export default {
+  title: 'Components/Banner',
+  component: Banner,
+  tags: ['autodocs'],
+} as Meta<BannerProps>
+
+const Template: StoryFn<BannerProps> = (args) => <Banner {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  children: 'You can insert a normal string here.',
+}
+
+export const Info = Template.bind({})
+Info.args = {
+  variant: 'info',
+  children: 'This is a dismissable info banner',
+  isDismissable: true,
+}
+
+export const Warn = Template.bind({})
+Warn.args = {
+  variant: 'warn',
+  children: 'This is a warning banner',
+}
+
+export const Error = Template.bind({})
+Error.args = {
+  variant: 'error',
+  children: 'This is an error banner',
+}
+
+export const Sizes: StoryFn<BannerProps> = (args) => (
+  <Stack>
+    <Banner {...args} variant="info">
+      This is a {args.size} dismissable info banner
+    </Banner>
+    <Banner {...args} variant="warn">
+      This is a {args.size} warning banner
+    </Banner>
+    <Banner {...args} variant="error">
+      This is a {args.size} error banner
+    </Banner>
+  </Stack>
+)
+Sizes.args = { size: 'md' }
+
+export const SmallSize = Sizes.bind({})
+SmallSize.args = { size: 'sm' }

--- a/packages/camp/src/Banner/Banner.tsx
+++ b/packages/camp/src/Banner/Banner.tsx
@@ -1,0 +1,77 @@
+import { type ElementType, useMemo } from 'react'
+import {
+  Box,
+  CloseButton,
+  Flex,
+  Icon,
+  useDisclosure,
+  useSlotRecipe,
+} from '@chakra-ui/react'
+
+import { BxsErrorCircle, BxsInfoCircle, BxX } from '~/icons'
+import type { BannerVariant } from '~/theme/slotRecipes/banner.slotRecipe'
+
+export interface BannerProps {
+  variant?: BannerVariant
+  size?: 'sm' | 'md'
+  children: React.ReactNode
+  /**
+   * Whether the banner can be dismissed.
+   * Defaults to `true` for the `info` variant and `false` otherwise.
+   */
+  isDismissable?: boolean
+  /**
+   * Icon to render at the start. Defaults to the variant's icon.
+   */
+  icon?: ElementType
+  /**
+   * Custom close button. Pass `null` to hide it. Defaults to a built-in
+   * close button.
+   */
+  closeButton?: React.ReactNode
+}
+
+export const Banner = ({
+  variant = 'info',
+  size = 'md',
+  children,
+  isDismissable: isDismissableProp,
+  icon: iconProp,
+  closeButton,
+}: BannerProps): JSX.Element | null => {
+  const { open, onToggle } = useDisclosure({ defaultOpen: true })
+
+  const recipe = useSlotRecipe({ key: 'banner' })
+  const styles = useMemo(
+    () => recipe({ variant, size }),
+    [recipe, variant, size],
+  )
+
+  const IconComponent =
+    iconProp ?? (variant === 'info' ? BxsInfoCircle : BxsErrorCircle)
+  const isDismissable = isDismissableProp ?? variant === 'info'
+
+  const closeButtonRendered = useMemo(() => {
+    if (!isDismissable) return null
+    if (closeButton !== undefined) return closeButton
+    return (
+      <CloseButton onClick={onToggle} css={styles.close}>
+        <BxX />
+      </CloseButton>
+    )
+  }, [closeButton, isDismissable, onToggle, styles.close])
+
+  if (!open) return null
+
+  return (
+    <Box css={styles.banner}>
+      <Flex css={styles.item}>
+        <Flex>
+          <Icon as={IconComponent} css={styles.icon} />
+          {children}
+        </Flex>
+        {closeButtonRendered}
+      </Flex>
+    </Box>
+  )
+}

--- a/packages/camp/src/Banner/index.ts
+++ b/packages/camp/src/Banner/index.ts
@@ -1,0 +1,1 @@
+export * from './Banner'

--- a/packages/camp/src/index.ts
+++ b/packages/camp/src/index.ts
@@ -1,5 +1,6 @@
 export * from './Avatar'
 export * from './Badge'
+export * from './Banner'
 export * from './Breadcrumb'
 export * from './Button'
 export * from './IconButton'

--- a/packages/camp/src/theme/config.ts
+++ b/packages/camp/src/theme/config.ts
@@ -4,6 +4,7 @@ import { badgeRecipe } from './recipes/badge.recipe'
 import { buttonRecipe } from './recipes/button.recipe'
 import { linkRecipe } from './recipes/link.recipe'
 import { avatarSlotRecipe } from './slotRecipes/avatar.slotRecipe'
+import { bannerSlotRecipe } from './slotRecipes/banner.slotRecipe'
 import { breadcrumbSlotRecipe } from './slotRecipes/breadcrumb.slotRecipe'
 import { infoboxSlotRecipe } from './slotRecipes/infobox.slotRecipe'
 import { tagSlotRecipe } from './slotRecipes/tag.slotRecipe'
@@ -48,6 +49,7 @@ export const config = defineConfig({
     },
     slotRecipes: {
       avatar: avatarSlotRecipe,
+      banner: bannerSlotRecipe,
       breadcrumb: breadcrumbSlotRecipe,
       infobox: infoboxSlotRecipe,
       tag: tagSlotRecipe,

--- a/packages/camp/src/theme/slotRecipes/banner.slotRecipe.ts
+++ b/packages/camp/src/theme/slotRecipes/banner.slotRecipe.ts
@@ -1,0 +1,101 @@
+import { defineSlotRecipe } from '@chakra-ui/react'
+
+export type BannerVariant = 'info' | 'warn' | 'error'
+
+export const bannerSlotRecipe = defineSlotRecipe({
+  slots: ['banner', 'item', 'icon', 'link', 'close'],
+  base: {
+    item: {
+      display: 'flex',
+      justifyContent: 'space-between',
+    },
+  },
+  variants: {
+    variant: {
+      info: {
+        banner: {
+          color: 'base.content.inverse',
+          bg: 'utility.feedback.info',
+        },
+        link: {
+          color: 'base.content.inverse',
+          _hover: { color: 'base.content.inverse' },
+        },
+        close: {
+          color: 'base.content.inverse',
+        },
+      },
+      warn: {
+        banner: {
+          color: 'base.content.strong',
+          bg: 'utility.feedback.warning',
+        },
+        link: {
+          color: 'base.content.strong',
+          _hover: { color: 'base.content.strong' },
+        },
+        close: {
+          color: 'base.content.strong',
+        },
+      },
+      error: {
+        banner: {
+          color: 'base.content.inverse',
+          bg: 'utility.feedback.critical',
+        },
+        link: {
+          color: 'base.content.inverse',
+          _hover: { color: 'base.content.inverse' },
+        },
+        close: {
+          color: 'base.content.inverse',
+        },
+      },
+    },
+    size: {
+      sm: {
+        item: {
+          py: '0.5rem',
+          px: '0.75rem',
+          textStyle: 'body-2',
+        },
+        icon: {
+          my: '0.125rem',
+          fontSize: '1rem',
+          mr: '0.5rem',
+        },
+        close: {
+          my: '-0.5rem',
+          ml: '0.5rem',
+          mr: '-0.5rem',
+          fontSize: '1rem',
+          w: '2.25rem',
+          h: '2.25rem',
+        },
+      },
+      md: {
+        item: {
+          py: '0.5rem',
+          px: '1rem',
+          textStyle: 'body-1',
+        },
+        icon: {
+          fontSize: '1.5rem',
+          mr: '0.5rem',
+        },
+        close: {
+          ml: '0.5rem',
+          mr: '-0.5rem',
+          my: '-0.375rem',
+          fontSize: '1.5rem',
+          w: '2.25rem',
+          h: '2.25rem',
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'info',
+    size: 'md',
+  },
+})

--- a/packages/camp/src/theme/slotRecipes/index.ts
+++ b/packages/camp/src/theme/slotRecipes/index.ts
@@ -3,6 +3,8 @@ export type {
   ThemeAvatarColorScheme,
 } from './avatar.slotRecipe'
 export { avatarSlotRecipe } from './avatar.slotRecipe'
+export type { BannerVariant } from './banner.slotRecipe'
+export { bannerSlotRecipe } from './banner.slotRecipe'
 export type {
   BreadcrumbColorPalette,
   ThemeBreadcrumbColorScheme,


### PR DESCRIPTION
Author a slot recipe matching v1 (banner + item + icon + link + close
slots) for info/warn/error variants and sm/md sizes. Wrapper picks the
variant-default icon (info → BxsInfoCircle, warn/error → BxsErrorCircle),
auto-dismisses for info-variant, and accepts custom close-button overrides.

Drops the `Collapse` wrapper from v1 — v3's `Collapsible` is a compound API
that doesn't fit the inline-render contract, and the v1 wrapper added a
visually transparent container without functional value to the standalone
banner (drift-audit confirms only nth-child structural noise vs main).