### PR TITLE
feat(camp): migrate Tabs slot recipe for v3

### DIFF
--- a/packages/camp/src/theme/config.ts
+++ b/packages/camp/src/theme/config.ts
@@ -17,6 +17,7 @@ import { menuSlotRecipe } from './slotRecipes/menu.slotRecipe'
 import { paginationSlotRecipe } from './slotRecipes/pagination.slotRecipe'
 import { radioGroupSlotRecipe } from './slotRecipes/radioGroup.slotRecipe'
 import { switchSlotRecipe } from './slotRecipes/switch.slotRecipe'
+import { tabsSlotRecipe } from './slotRecipes/tabs.slotRecipe'
 import { tagSlotRecipe } from './slotRecipes/tag.slotRecipe'
 import { tileSlotRecipe } from './slotRecipes/tile.slotRecipe'
 import { toggleSlotRecipe } from './slotRecipes/toggle.slotRecipe'
@@ -75,6 +76,7 @@ export const config = defineConfig({
       pagination: paginationSlotRecipe,
       radioGroup: radioGroupSlotRecipe,
       switch: switchSlotRecipe,
+      tabs: tabsSlotRecipe,
       tag: tagSlotRecipe,
       tile: tileSlotRecipe,
       toggle: toggleSlotRecipe,

--- a/packages/camp/src/theme/slotRecipes/index.ts
+++ b/packages/camp/src/theme/slotRecipes/index.ts
@@ -25,6 +25,7 @@ export type {
   ThemeSwitchColorScheme,
 } from './switch.slotRecipe'
 export { switchSlotRecipe } from './switch.slotRecipe'
+export { tabsSlotRecipe } from './tabs.slotRecipe'
 export type { TagColorPalette, ThemeTagColorScheme } from './tag.slotRecipe'
 export { tagSlotRecipe } from './tag.slotRecipe'
 export type { TileVariant } from './tile.slotRecipe'

--- a/packages/camp/src/theme/slotRecipes/tabs.slotRecipe.ts
+++ b/packages/camp/src/theme/slotRecipes/tabs.slotRecipe.ts
@@ -1,0 +1,81 @@
+import { defineSlotRecipe } from '@chakra-ui/react'
+
+export const tabsSlotRecipe = defineSlotRecipe({
+  slots: ['root', 'list', 'trigger', 'content', 'indicator'],
+  base: {
+    list: {
+      overflowX: 'auto',
+      overflowY: 'initial',
+      whiteSpace: 'nowrap',
+      scrollbarWidth: 'none',
+      '&::-webkit-scrollbar': {
+        width: 0,
+        height: 0,
+      },
+    },
+    trigger: {
+      color: 'interaction.support.unselected',
+      borderBottom: '2px solid transparent',
+      marginBottom: '-2px',
+      _selected: {
+        color: 'interaction.main.default',
+        borderColor: 'interaction.main.default',
+      },
+      _hover: {
+        color: 'interaction.main.hover',
+      },
+      _focusVisible: {
+        outline: '2px solid var(--chakra-colors-utility-focus-default)',
+        outlineOffset: 0,
+      },
+    },
+    content: {
+      p: 'initial',
+    },
+  },
+  variants: {
+    orientation: {
+      vertical: {
+        list: {
+          overflowX: 'initial',
+          overflowY: 'auto',
+        },
+        trigger: {
+          borderBottom: 'none',
+          borderInlineStart: '2px solid transparent',
+          marginInlineStart: '-2px',
+          marginBottom: 0,
+          _hover: {
+            bg: 'interaction.muted.main.hover',
+            color: 'interaction.main.hover',
+          },
+          _selected: {
+            borderInlineStartColor: 'interaction.main.default',
+          },
+        },
+      },
+    },
+    size: {
+      sm: {
+        list: { gap: '2rem' },
+        trigger: {
+          px: 0,
+          py: '0.25rem',
+          textStyle: 'body-2',
+        },
+      },
+      md: {
+        list: { gap: '2rem' },
+        trigger: {
+          px: 0,
+          py: '0.25rem',
+          mx: '0.25rem',
+          textStyle: 'subhead-3',
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+})


### PR DESCRIPTION
v3 ships Tabs as compound API natively (Root/List/Trigger/Content/
Indicator); consumer code uses the chakra codemod for the rename. This
commit ships only the slot recipe matching v1's line variant:
- Unselected tabs in interaction.support.unselected
- Selected/hover in interaction.main
- Bottom-border indicator at -2px overlap on horizontal orientation
- Inline-start border on vertical orientation
- Hidden scrollbar on the list for horizontal scroll
- sm/md sizes with body-2 / subhead-3 typography

Drops v1's DarkMode wrapper (v3 dropped color-mode primitives) — camp
remains light-mode only per the foundation decision.